### PR TITLE
fixing possible issue with Supervisor Monitor setting

### DIFF
--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -326,7 +326,7 @@ class WebServiceProvider extends ServiceProvider
                 config('web.supervisor.rpc.address'),
                 config('web.supervisor.rpc.username'),
                 config('web.supervisor.rpc.password'),
-                config('web.supervisor.rpc.port')
+                (int) config('web.supervisor.rpc.port')
             );
         });
 


### PR DESCRIPTION
fixing possible issue with Supervisor Monitor setting due to port config type returned as string instead an integer (thanks to gunfighterj)