### PR TITLE
Fix null exception on page which require permission for unauth user

### DIFF
--- a/src/Http/Middleware/Bouncer/Bouncer.php
+++ b/src/Http/Middleware/Bouncer/Bouncer.php
@@ -50,6 +50,10 @@ class Bouncer
         // Get the currently logged in user
         $user = auth()->user();
 
+        if ($user == null) {
+            return redirect()->guest('auth/login');
+        }
+
         // Check on the clipboard if this permission
         // should be granted.
         if ($user->has($permission, false))


### PR DESCRIPTION
Redirect unauth user to authentication page instead throwing a null exception.