### PR TITLE
Allow to add custom content from a child template to <head>

### DIFF
--- a/src/resources/views/layouts/app-mini.blade.php
+++ b/src/resources/views/layouts/app-mini.blade.php
@@ -18,6 +18,8 @@
   <!-- Theme style -->
   <link rel="stylesheet" href="{{ asset('web/css/adminlte.min.css') }}">
 
+  @stack('head')
+
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -27,7 +27,7 @@
   <!-- SeAT CSS -->
   <link rel="stylesheet" href="{{ asset('web/css/seat.css') }}">
 
-  @stack('stylesheet')
+  @stack('head')
 
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -27,6 +27,8 @@
   <!-- SeAT CSS -->
   <link rel="stylesheet" href="{{ asset('web/css/seat.css') }}">
 
+  @stack('stylesheet')
+
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
   <!--[if lt IE 9]>


### PR DESCRIPTION
Allow a child template to add content to the `<head>` of the main layout by using the `push` directive. Useful to add  a custom css for example :

(example.blade.php)
```
[...]
@push('head')
  <link rel="stylesheet" href="{{ asset('a/custom/stylesheet.css') }}">
@endpush