### PR TITLE
Improved Tools>People Groups layout

### DIFF
--- a/src/resources/views/people/list.blade.php
+++ b/src/resources/views/people/list.blade.php
@@ -59,7 +59,7 @@
     </div>
     <div class="panel-body">
         <div class="col-md-12">
-          <table class="table compact table-condensed table-hover table-responsive" id="characters">
+          <table class="table compact table-condensed table-responsive" id="characters">
             <thead>
               <tr>
                 <th>{{ trans('web::seat.main_character') }}</th>

--- a/src/resources/views/people/list.blade.php
+++ b/src/resources/views/people/list.blade.php
@@ -58,67 +58,58 @@
       <h3 class="panel-title">{{ trans('web::seat.people_groups') }}</h3>
     </div>
     <div class="panel-body">
-
         <div class="col-md-12">
-
           <table class="table compact table-condensed table-hover table-responsive" id="characters">
             <thead>
               <tr>
                 <th>{{ trans('web::seat.main_character') }}</th>
+                <th>{{ trans('web::seat.key') }}</th>
                 <th>{{ trans_choice('web::seat.character', 2) }}</th>
                 <th>{{ trans_choice('web::seat.corporation', 1) }}</th>
-                <th>{{ trans('web::seat.key') }}</th>
                 <th>{{ trans('web::seat.actions') }}</th>
               </tr>
             </thead>
             <tbody>
               @foreach($people as $person)
-
                 <tr>
                   <td id="main_character" class="{{$person->main_character_id}}">
                     {!! img('character', $person->main_character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
                     {{ $person->main_character_name }}
                   </td>
-
-                    @foreach($person->members as $member)
-
-                        @foreach($member->characters as $character)
+                </tr>
+                  @foreach($person->members as $member)
+                      @foreach($member->characters as $character)
                         <tr id="characters" class="{{$person->main_character_id}}">
+                          @if ($loop->first)
+                            <td rowspan="{{ count($member->characters) }}">
+                              <span class="text-muted">Key: {{ $member->key_id }}</span>
+                            </td>
+                          @endif
                           <td>
                             <a href="{{ route('character.view.sheet', ['character_id' => $character->characterID]) }}">
                               {!! img('character', $character->characterID, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
                               {{ $character->characterName }}
                             </a>
                           </td>
-
                           <td>
                             {{ $character->corporationName }}
                           </td>
-
                           <td>
-                            <span>Key: {{ $member->key_id }}</span>
-                          </td>
-
-                          <td>
-                            <a href="{{ route('people.remove.group.key', ['group_id' => $person->id, 'key_id' => $member->key_id]) }}"><i class="fa fa-chain-broken"></i></a>
-                            &nbsp;
                             <a href="{{ route('people.set.main', ['group_id' => $person->id, 'character_id' => $character->characterID]) }}"data-toggle="tooltip"
                                title="" data-original-title="Set {{ $character->characterName }} as Main">
                               <i class="fa fa-angle-double-up"></i>
                             </a>
+                            @if ($loop->first)
+                              &nbsp;<a href="{{ route('people.remove.group.key', ['group_id' => $person->id, 'key_id' => $member->key_id]) }}"><i class="fa fa-chain-broken"></i></a>
+                            @endif
                           </td>
-
                         </tr>
                       @endforeach
-
                     @endforeach
-                </tr>
               @endforeach
             </tbody>
           </table>
-
         </div>
-
     </div>
   </div>
 

--- a/src/resources/views/people/list.blade.php
+++ b/src/resources/views/people/list.blade.php
@@ -59,66 +59,65 @@
     </div>
     <div class="panel-body">
 
-      @foreach($people as $person)
-
         <div class="col-md-12">
 
-          <div class="col-md-3">
+          <table class="table compact table-condensed table-hover table-responsive" id="characters">
+            <thead>
+              <tr>
+                <th>{{ trans('web::seat.main_character') }}</th>
+                <th>{{ trans_choice('web::seat.character', 2) }}</th>
+                <th>{{ trans_choice('web::seat.corporation', 1) }}</th>
+                <th>{{ trans('web::seat.key') }}</th>
+                <th>{{ trans('web::seat.actions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach($people as $person)
 
-            <dl class="">
-              <dt>{{ trans('web::seat.main_character') }}</dt>
-              <dd>
-                {!! img('character', $person->main_character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
-                {{ $person->main_character_name }}
-              </dd>
-              <dt>{{ trans('web::seat.actions') }}</dt>
-              <dd>
-                <a href="{{ route('people.remove.group', ['group_id' => $person->id]) }}">
-                  {{ trans('web::seat.remove') }}
-                </a>
-              </dd>
-            </dl>
+                <tr>
+                  <td id="main_character" class="{{$person->main_character_id}}">
+                    {!! img('character', $person->main_character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+                    {{ $person->main_character_name }}
+                  </td>
 
-          </div>
-          <div class="col-md-9">
+                    @foreach($person->members as $member)
 
-            @foreach($person->members as $member)
+                        @foreach($member->characters as $character)
+                        <tr id="characters" class="{{$person->main_character_id}}">
+                          <td>
+                            <a href="{{ route('character.view.sheet', ['character_id' => $character->characterID]) }}">
+                              {!! img('character', $character->characterID, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+                              {{ $character->characterName }}
+                            </a>
+                          </td>
 
-              <ul class="list-unstyled">
-                <li>
-                  <span class="text-muted">Key: {{ $member->key_id }}</span>
-                  <a href="{{ route('people.remove.group.key', ['group_id' => $person->id, 'key_id' => $member->key_id]) }}"
-                     class="pull-right">
-                    {{ trans('web::seat.remove') }}
-                  </a>
-                </li>
+                          <td>
+                            {{ $character->corporationName }}
+                          </td>
 
-                @foreach($member->characters as $character)
+                          <td>
+                            <span>Key: {{ $member->key_id }}</span>
+                          </td>
 
-                  <li>
-                    <a href="{{ route('character.view.sheet', ['character_id' => $character->characterID]) }}">
-                      {!! img('character', $character->characterID, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
-                      {{ $character->characterName }}
-                    </a>
-                    <a href="{{ route('people.set.main', ['group_id' => $person->id, 'character_id' => $character->characterID]) }}"
-                       class="pull-right" data-toggle="tooltip"
-                       title="" data-original-title="Set {{ $character->characterName }} as Main">
-                      <i class="fa fa-link"></i>
-                    </a>
-                  </li>
+                          <td>
+                            <a href="{{ route('people.remove.group.key', ['group_id' => $person->id, 'key_id' => $member->key_id]) }}"><i class="fa fa-chain-broken"></i></a>
+                            &nbsp;
+                            <a href="{{ route('people.set.main', ['group_id' => $person->id, 'character_id' => $character->characterID]) }}"data-toggle="tooltip"
+                               title="" data-original-title="Set {{ $character->characterName }} as Main">
+                              <i class="fa fa-angle-double-up"></i>
+                            </a>
+                          </td>
 
-                @endforeach
+                        </tr>
+                      @endforeach
 
-              </ul>
-              <hr>
-
-            @endforeach
-
-          </div>
+                    @endforeach
+                </tr>
+              @endforeach
+            </tbody>
+          </table>
 
         </div>
-
-      @endforeach
 
     </div>
   </div>
@@ -189,6 +188,11 @@
         };
       },
     }
+  });
+
+  $("td#main_character").each(function(index, td) {
+    var characters = $("table#characters").find("tr[class=" + $(this).attr('class') + "]").length + 1;
+    $(this).attr('rowspan', characters);
   });
 
 </script>


### PR DESCRIPTION
I found the feature awesome but hard to navigate and I think this rework is a bit clearer than the current one.

Current : 
![old](https://cloud.githubusercontent.com/assets/5278648/22627388/a8e0cf38-ebc2-11e6-8787-4c31125b05ad.JPG)

After : 
![new](https://cloud.githubusercontent.com/assets/5278648/22627390/af5d189e-ebc2-11e6-876a-0d7f2dd02aeb.JPG)

Still no luck with DataTables tho since it does not handle rowspans in the tbody tag.