### PR TITLE
Add item and client filtering to wallet transactions

### DIFF
--- a/src/Http/Controllers/Character/WalletController.php
+++ b/src/Http/Controllers/Character/WalletController.php
@@ -168,6 +168,12 @@ class WalletController extends Controller
                 return view('web::partials.transactionclient', compact('row'))
                     ->render();
             })
+            ->filter(function ($query) {
+                if (request()->has('search.value')) {
+                    $query->where('typeName', 'like', '%' . request()->input('search.value') . '%')
+                    ->orWhere('clientName', 'like', '%' . request()->input('search.value') . '%');
+                }
+            })
             ->make(true);
 
     }


### PR DESCRIPTION
Previously wallet transaction filtering would only filter by client name. This PR adds filtering for both client name and item name.