### PR TITLE
the current delete statement is not firing the delete event

### DIFF
--- a/src/Http/Controllers/Api/KeyController.php
+++ b/src/Http/Controllers/Api/KeyController.php
@@ -218,7 +218,7 @@ class KeyController extends Controller
     public function getDelete($key_id)
     {
 
-        ApiKeyModel::where('key_id', $key_id)
+        ApiKeyModel::find($key_id)
             ->delete();
 
         return redirect()->back()


### PR DESCRIPTION
the current delete statement is not firing the delete event from eloquent

therefore, attached characters and key info will never been dropped

https://laravel.com/docs/5.4/eloquent#deleting-models