### PR TITLE
allow SeAT owner to overload theme using two custom css file

### DIFF
--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -121,19 +121,6 @@ class WebServiceProvider extends ServiceProvider
             base_path('vendor/components/font-awesome/css/font-awesome.min.css') => public_path('web/css/font-awesome.min.css'),
             base_path('vendor/components/font-awesome/fonts') => public_path('web/fonts'),
         ]);
-
-        // Check if theme overload exists and publish it
-        if (file_exists(base_path('custom-layout.css'))) {
-            $this->publishes([
-                base_path('custom-layout.css') => public_path('web/css/custom-layout.css'),
-            ]);
-        }
-
-        if (file_exists(base_path('custom-layout-mini.css'))) {
-            $this->publishes([
-                base_path('custom-layout-mini.css') => public_path('web/css/custom-layout-mini.css'),
-            ]);
-        }
     }
 
     /**

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -121,6 +121,19 @@ class WebServiceProvider extends ServiceProvider
             base_path('vendor/components/font-awesome/css/font-awesome.min.css') => public_path('web/css/font-awesome.min.css'),
             base_path('vendor/components/font-awesome/fonts') => public_path('web/fonts'),
         ]);
+
+        // Check if theme overload exists and publish it
+        if (file_exists(base_path('custom-layout.css'))) {
+            $this->publishes([
+                base_path('custom-layout.css') => public_path('web/css/custom-layout.css'),
+            ]);
+        }
+
+        if (file_exists(base_path('custom-layout-mini.css'))) {
+            $this->publishes([
+                base_path('custom-layout-mini.css') => public_path('web/css/custom-layout-mini.css'),
+            ]);
+        }
     }
 
     /**

--- a/src/resources/views/layouts/app-mini.blade.php
+++ b/src/resources/views/layouts/app-mini.blade.php
@@ -18,6 +18,11 @@
   <!-- Theme style -->
   <link rel="stylesheet" href="{{ asset('web/css/adminlte.min.css') }}">
 
+  @if(file_exists(public_path('web/css/custom-layout-mini.css')))
+  <!-- Custom layout CSS -->
+  <link rel="stylesheet" href="{{ asset('web/css/custom-layout-mini.css') }}" />
+  @endif
+
   <!-- view specfic head content -->
   @stack('head')
 

--- a/src/resources/views/layouts/app-mini.blade.php
+++ b/src/resources/views/layouts/app-mini.blade.php
@@ -18,9 +18,9 @@
   <!-- Theme style -->
   <link rel="stylesheet" href="{{ asset('web/css/adminlte.min.css') }}">
 
-  @if(file_exists(public_path('web/css/custom-layout-mini.css')))
+  @if(file_exists(public_path('custom-layout-mini.css')))
   <!-- Custom layout CSS -->
-  <link rel="stylesheet" href="{{ asset('web/css/custom-layout-mini.css') }}" />
+  <link rel="stylesheet" href="{{ asset('custom-layout-mini.css') }}" />
   @endif
 
   <!-- view specfic head content -->

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -26,6 +26,10 @@
   <link rel="stylesheet" href="{{ asset('web/css/skins/' . setting('skin') . '.min.css') }}">
   <!-- SeAT CSS -->
   <link rel="stylesheet" href="{{ asset('web/css/seat.css') }}">
+  @if(file_exists(public_path('web/css/custom-layout.css')))
+  <!-- Custom layout CSS -->
+  <link rel="stylesheet" href="{{ asset('web/css/custom-layout.css') }}" />
+  @endif
 
   <!-- view specfic head content -->
   @stack('head')

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -26,9 +26,9 @@
   <link rel="stylesheet" href="{{ asset('web/css/skins/' . setting('skin') . '.min.css') }}">
   <!-- SeAT CSS -->
   <link rel="stylesheet" href="{{ asset('web/css/seat.css') }}">
-  @if(file_exists(public_path('web/css/custom-layout.css')))
+  @if(file_exists(public_path('custom-layout.css')))
   <!-- Custom layout CSS -->
-  <link rel="stylesheet" href="{{ asset('web/css/custom-layout.css') }}" />
+  <link rel="stylesheet" href="{{ asset('custom-layout.css') }}" />
   @endif
 
   <!-- view specfic head content -->


### PR DESCRIPTION
- custom-layout-mini.css is used on login page
- custom-layout.css is used everywhere else

1) create one of the css file or both at the SeAT root directory
2) run `php artisan vendor:publish` in order to publish them

This feature must be used by user and not integrator which can access to header with `head stack`