### PR TITLE
fix hasrole method by calling magic property instead method.

### DIFF
--- a/src/Acl/AccessChecker.php
+++ b/src/Acl/AccessChecker.php
@@ -421,7 +421,7 @@ trait AccessChecker
         if ($this->hasSuperUser())
             return true;
 
-        foreach ($this->roles() as $role)
+        foreach ($this->roles as $role)
             if ($role->title == $role_name)
                 return true;
 


### PR DESCRIPTION
Laravel documentation example :

```
$user = App\User::find(1);

foreach ($user->roles as $role) {
    //
}
```

Impact API package which was always returning false for user who were not super user