### PR TITLE
#322 - Adding Support for External Authorization. Use separate ESI auths for Login and ESI Pull

### DIFF
--- a/src/Config/web.config.php
+++ b/src/Config/web.config.php
@@ -22,7 +22,7 @@
 
 return [
 
-    'version'                  => '3.0.0-beta16',
+    'version'                  => '3.0.0-beta17',
     'queue_status_update_time' => 10 * 1000, // milliseconds = seconds x 1,000
 
 ];

--- a/src/Config/web.config.php
+++ b/src/Config/web.config.php
@@ -22,7 +22,7 @@
 
 return [
 
-    'version'                  => '3.0.0-beta15',
+    'version'                  => '3.0.0-beta16',
     'queue_status_update_time' => 10 * 1000, // milliseconds = seconds x 1,000
 
 ];

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -76,7 +76,7 @@ class LoginController extends Controller
     {
 
         // Warn if SSO has not been configured yet.
-        if (strlen(env('EVE_CLIENT_SECRET')) < 5 || strlen(env('EVE_CLIENT_ID')) < 5)
+        if (strlen(env('LOGIN_CLIENT_SECRET')) < 5 || strlen(env('LOGIN_CLIENT_ID')) < 5)
             session()->flash('warning', trans('web::seat.sso_config_warning'));
 
         return view('web::auth.login');

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -45,7 +45,11 @@ class SsoController extends Controller
      */
     public function redirectToProvider(Socialite $social)
     {
+        
+        // if using external auth dont ask for scopes
+        if (env('EXTERNAL_AUTH')) return $social->driver('eveonline')->redirect();
 
+        // Standard Login - ask for Scopes
         return $social->driver('eveonline')
             ->scopes(setting('sso_scopes', true))
             ->redirect();
@@ -135,6 +139,11 @@ class SsoController extends Controller
             return $existing;
         }
 
+        // If using external Auth and user does not exist
+        if (env('EXTERNAL_AUTH')){
+            abort(403,'No Authorized User Found');
+        }
+        
         // Log the new account creation
         event('security.log', [
             'Creating new account for ' . $eve_user->name, 'authentication',

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -129,7 +129,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function settings()
     {
 
-        return $this->hasMany(UserSetting::class);
+        return $this->hasMany(UserSetting::class, 'group_id', 'group_id');
     }
 
     /**

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -349,7 +349,7 @@ class WebServiceProvider extends ServiceProvider
         $eveonline->extend('eveonline',
             function ($app) use ($eveonline) {
 
-                $config = $app['config']['services.eveonline'];
+                $config = $app['config']['services.evelogin'];
 
                 return $eveonline->buildProvider(EveOnlineProvider::class, $config);
             }


### PR DESCRIPTION
This is part of possible changes for allowing the use of an External Auth system to create users and ESI keys from a 3rd party auth system.

These changes ...
- Use a different Client_id/Secret_key pair that matches the External Auth system for the ESI data pull
- Prevent Users from Logging in unless a user has already been created by the external Auth system

Changes are also made to the .env config file in eveseat/seat to support this.