### PR TITLE
[DRAFT] Widget implementation draft proposal

### DIFF
--- a/src/Http/Composers/ProfileWidgets.php
+++ b/src/Http/Composers/ProfileWidgets.php
@@ -1,0 +1,43 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Http\Composers;
+
+
+use Illuminate\Contracts\View\View;
+
+class ProfileWidgets
+{
+    /**
+     * @param View $view
+     * @return $this|View
+     */
+    public function compose(View $view)
+    {
+        switch ($view->name()) {
+            case 'web::profile.includes.widgets':
+                return $view->with('widgets', app('profile_widgets')->getWidgets());
+        }
+
+        return $view;
+    }
+
+}

--- a/src/Http/Composers/ProfileWidgets.php
+++ b/src/Http/Composers/ProfileWidgets.php
@@ -1,26 +1,26 @@
 <?php
+
 /*
-This file is part of SeAT
-
-Copyright (C) 2015, 2016  Leon Jacobs
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 namespace Seat\Web\Http\Composers;
-
 
 use Illuminate\Contracts\View\View;
 
@@ -39,5 +39,4 @@ class ProfileWidgets
 
         return $view;
     }
-
 }

--- a/src/Models/Widgets/IWidget.php
+++ b/src/Models/Widgets/IWidget.php
@@ -1,0 +1,48 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Models\Widgets;
+
+
+interface IWidget
+{
+
+    /**
+     * @return string
+     */
+    public function getTitle() : string;
+
+    /**
+     * @return null|string
+     */
+    public function getFooter() : ?string;
+
+    /**
+     * @return string
+     */
+    public function getBodyTemplate() : string;
+
+    /**
+     * @return mixed
+     */
+    public function getDataset();
+
+}

--- a/src/Models/Widgets/IWidget.php
+++ b/src/Models/Widgets/IWidget.php
@@ -1,30 +1,29 @@
 <?php
+
 /*
-This file is part of SeAT
-
-Copyright (C) 2015, 2016  Leon Jacobs
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 namespace Seat\Web\Models\Widgets;
 
-
 interface IWidget
 {
-
     /**
      * @return string
      */
@@ -44,5 +43,4 @@ interface IWidget
      * @return mixed
      */
     public function getDataset();
-
 }

--- a/src/Models/Widgets/ProfileWidget.php
+++ b/src/Models/Widgets/ProfileWidget.php
@@ -1,30 +1,29 @@
 <?php
+
 /*
-This file is part of SeAT
-
-Copyright (C) 2015, 2016  Leon Jacobs
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 namespace Seat\Web\Models\Widgets;
 
-
 class ProfileWidget implements IWidget
 {
-
     /**
      * @var string
      */

--- a/src/Models/Widgets/ProfileWidget.php
+++ b/src/Models/Widgets/ProfileWidget.php
@@ -1,0 +1,94 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Models\Widgets;
+
+
+class ProfileWidget implements IWidget
+{
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $footer;
+
+    /**
+     * @var string
+     */
+    private $body_template;
+
+    /**
+     * @var null
+     */
+    private $dataset;
+
+    /**
+     * ProfileWidget constructor.
+     * @param string $title
+     * @param string $body_template
+     * @param null $dataset
+     * @param string|null $footer
+     */
+    public function __construct(string $title, string $body_template, $dataset = null, string $footer = null)
+    {
+        $this->title = $title;
+        $this->body_template = $body_template;
+        $this->dataset = $dataset;
+        $this->footer = $footer;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getFooter(): ?string
+    {
+        return $this->footer;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyTemplate(): string
+    {
+        return $this->body_template;
+    }
+
+    /**
+     * @return null
+     */
+    public function getDataset()
+    {
+        return $this->dataset;
+    }
+}

--- a/src/Repositories/AbstractWidgetRepository.php
+++ b/src/Repositories/AbstractWidgetRepository.php
@@ -1,0 +1,59 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Repositories;
+
+
+use Seat\Web\Models\Widgets\IWidget;
+
+class AbstractWidgetRepository
+{
+
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $widgets;
+
+    /**
+     * AbstractWidgetRepository constructor.
+     */
+    public function __construct()
+    {
+        $this->widgets = collect();
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getWidgets()
+    {
+        return $this->widgets;
+    }
+
+    /**
+     * @param IWidget $widget
+     */
+    protected function push(IWidget $widget)
+    {
+        $this->widgets->push($widget);
+    }
+
+}

--- a/src/Repositories/AbstractWidgetRepository.php
+++ b/src/Repositories/AbstractWidgetRepository.php
@@ -1,32 +1,31 @@
 <?php
+
 /*
-This file is part of SeAT
-
-Copyright (C) 2015, 2016  Leon Jacobs
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 namespace Seat\Web\Repositories;
-
 
 use Seat\Web\Models\Widgets\IWidget;
 
 class AbstractWidgetRepository
 {
-
     /**
      * @var \Illuminate\Support\Collection
      */
@@ -55,5 +54,4 @@ class AbstractWidgetRepository
     {
         $this->widgets->push($widget);
     }
-
 }

--- a/src/Repositories/Widgets/ProfileWidgetRepository.php
+++ b/src/Repositories/Widgets/ProfileWidgetRepository.php
@@ -1,33 +1,32 @@
 <?php
+
 /*
-This file is part of SeAT
-
-Copyright (C) 2015, 2016  Leon Jacobs
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 namespace Seat\Web\Repositories\Widgets;
-
 
 use Seat\Web\Models\Widgets\ProfileWidget;
 use Seat\Web\Repositories\AbstractWidgetRepository;
 
 class ProfileWidgetRepository extends AbstractWidgetRepository
 {
-
     /**
      * @param ProfileWidget $widget
      */
@@ -35,5 +34,4 @@ class ProfileWidgetRepository extends AbstractWidgetRepository
     {
         $this->push($widget);
     }
-
 }

--- a/src/Repositories/Widgets/ProfileWidgetRepository.php
+++ b/src/Repositories/Widgets/ProfileWidgetRepository.php
@@ -1,0 +1,39 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Repositories\Widgets;
+
+
+use Seat\Web\Models\Widgets\ProfileWidget;
+use Seat\Web\Repositories\AbstractWidgetRepository;
+
+class ProfileWidgetRepository extends AbstractWidgetRepository
+{
+
+    /**
+     * @param ProfileWidget $widget
+     */
+    public function register(ProfileWidget $widget)
+    {
+        $this->push($widget);
+    }
+
+}

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -42,6 +42,7 @@ use Seat\Web\Http\Composers\CharacterSummary;
 use Seat\Web\Http\Composers\CorporationMenu;
 use Seat\Web\Http\Composers\CorporationSummary;
 use Seat\Web\Http\Composers\Esi;
+use Seat\Web\Http\Composers\ProfileWidgets;
 use Seat\Web\Http\Composers\Sidebar;
 use Seat\Web\Http\Composers\User;
 use Seat\Web\Http\Middleware\Authenticate;
@@ -52,6 +53,7 @@ use Seat\Web\Http\Middleware\Bouncer\KeyBouncer;
 use Seat\Web\Http\Middleware\Locale;
 use Seat\Web\Http\Middleware\RegistrationAllowed;
 use Seat\Web\Http\Middleware\Requirements;
+use Seat\Web\Repositories\Widgets\ProfileWidgetRepository;
 use Validator;
 
 /**
@@ -154,6 +156,10 @@ class WebServiceProvider extends ServiceProvider
         // Sidebar menu view composer
         $this->app['view']->composer(
             'web::includes.sidebar', Sidebar::class);
+
+        // Profile widgets composer
+        $this->app['view']->composer(
+            'web::profile.includes.widgets', ProfileWidgets::class);
 
         // Character info composer
         $this->app['view']->composer([
@@ -367,16 +373,10 @@ class WebServiceProvider extends ServiceProvider
         $loader = AliasLoader::getInstance();
         $loader->alias('Datatables', 'Yajra\Datatables\Facades\Datatables');
 
-        // Register the Supervisor RPC helper into the IoC
-        $this->app->singleton('supervisor', function () {
+        // Register Widget repositories
+        $this->app->singleton('profile_widgets', function () {
 
-            return new Supervisor(
-                config('web.supervisor.name'),
-                config('web.supervisor.rpc.address'),
-                config('web.supervisor.rpc.username'),
-                config('web.supervisor.rpc.password'),
-                (int) config('web.supervisor.rpc.port')
-            );
+            return new ProfileWidgetRepository();
         });
 
     }

--- a/src/resources/views/profile/includes/widgets.blade.php
+++ b/src/resources/views/profile/includes/widgets.blade.php
@@ -1,0 +1,13 @@
+@foreach ($widgets as $widget)
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">{{ $widget->getTitle() }}</h3>
+    </div>
+    <div class="panel-body">
+        @include($widget->getBodyTemplate(), ['dataset' => $widget->getDataset()])
+    </div>
+    @if(! is_null($widget->getFooter()))
+    <div class="panel-footer">{{ $widget->getFooter() }}</div>
+    @endif
+</div>
+@endforeach

--- a/src/resources/views/profile/view.blade.php
+++ b/src/resources/views/profile/view.blade.php
@@ -392,6 +392,7 @@
     </div>
   </div>
 
+  @if(auth()->user()->name != 'admin')
   <div class="panel panel-default">
     <div class="panel-body">
       <p>
@@ -404,7 +405,6 @@
     </div>
   </div>
 
-  @if(auth()->user()->name != 'admin')
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">
@@ -444,6 +444,8 @@
     </div>
   </div>
   @endif
+
+  @include('web::profile.includes.widgets')
 
   <span class="text-center">
     {{ trans('web::seat.account_help') }}


### PR DESCRIPTION
This is a a widget implementation draft proposal in order to allow plugin to overload some part of core layouts (ie: profile).

Here's the usage :
In the plugin ServiceProvider create as many as desired Widgets and seed them into proper container (actually, only `profile_widget`).

```
$widget = new ProfileWidget('widget title', 'widget blade template', 'dataset', 'footer');
$this->app['profile_widget']->register($widget);
```

For exemple, if I want to append a `Discord Widget` with some server connection link on the Profile layout, I'll do the following :

```
$widget = new ProfileWidget('Discord Connector', 'discord-connector::core.profile.widgets.discord');
$this->app['profile_widget']->register($widget);
```

This will result in the following

![image](https://user-images.githubusercontent.com/648753/40748757-c17bc4e4-6461-11e8-9fd6-540468ee14cc.png)
