### PR TITLE
User list redesign paginated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "eveseat/services": "~3",
     "league/csv": "^9.1",
     "guzzlehttp/guzzle": "^6.3",
-    "yajra/laravel-datatables-oracle": "~6",
+    "yajra/laravel-datatables-oracle": "8.*",
+    "yajra/laravel-datatables-buttons": "3.*",
     "components/font-awesome": "^4.7"
   },
   "extra": {

--- a/src/Http/Controllers/Character/CharacterController.php
+++ b/src/Http/Controllers/Character/CharacterController.php
@@ -25,7 +25,6 @@ namespace Seat\Web\Http\Controllers\Character;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Services\Repositories\Character\Character;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class CharacterController.
@@ -53,7 +52,7 @@ class CharacterController extends Controller
 
         $characters = $this->getAllCharactersWithAffiliations();
 
-        return Datatables::of($characters)
+        return app('DataTables')::of($characters)
             ->editColumn('name', function ($row) {
 
                 return view('web::character.partials.charactername', compact('row'))

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Character;
 
 use Seat\Services\Repositories\Character\Contracts;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class ContractsController.
@@ -56,7 +55,7 @@ class ContractsController extends Controller
 
         $contracts = $this->getCharacterContracts($character_id, false);
 
-        return Datatables::of($contracts)
+        return app('DataTables')::of($contracts)
             ->editColumn('issuer_id', function ($row) {
 
                 return view('web::partials.contractissuer', compact('row'))

--- a/src/Http/Controllers/Character/IndustryController.php
+++ b/src/Http/Controllers/Character/IndustryController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Character;
 
 use Seat\Services\Repositories\Character\Industry;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class IndustryController.
@@ -55,7 +54,7 @@ class IndustryController extends Controller
 
         $jobs = $this->getCharacterIndustry($character_id, false);
 
-        return Datatables::of($jobs)
+        return app('DataTables')::of($jobs)
             ->editColumn('installerName', function ($row) {
 
                 return view('web::partials.industryinstaller', compact('row'))

--- a/src/Http/Controllers/Character/IntelController.php
+++ b/src/Http/Controllers/Character/IntelController.php
@@ -27,7 +27,6 @@ use Seat\Services\Repositories\Character\Intel;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Web\Http\Validation\NewIntelNote;
 use Seat\Web\Http\Validation\UpdateIntelNote;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class IntelController.
@@ -63,7 +62,7 @@ class IntelController extends Controller
 
         $top = $this->characterTopWalletJournalInteractions($character_id);
 
-        return Datatables::of($top)
+        return app('DataTables')::of($top)
             ->editColumn('ref_type', function ($row) {
 
                 return ucwords(str_replace('_', ' ', $row->ref_type));
@@ -97,7 +96,7 @@ class IntelController extends Controller
 
         $top = $this->characterTopWalletTransactionInteractions($character_id);
 
-        return Datatables::of($top)
+        return app('DataTables')::of($top)
             ->editColumn('character_id', function ($row) {
 
                 return view('web::character.intel.partials.charactername', compact('row'))
@@ -127,7 +126,7 @@ class IntelController extends Controller
 
         $top = $this->characterTopMailInteractions($character_id);
 
-        return Datatables::of($top)
+        return app('DataTables')::of($top)
             ->editColumn('character_id', function ($row) {
 
                 return view('web::character.intel.partials.charactername', compact('row'))
@@ -170,7 +169,7 @@ class IntelController extends Controller
 
         $journal = $this->getCharacterJournalStandingsWithProfile($character_id, $profile_id);
 
-        return Datatables::of($journal)
+        return app('DataTables')::of($journal)
             ->editColumn('characterName', function ($row) {
 
                 return view('web::character.intel.partials.charactername', compact('row'))
@@ -210,7 +209,7 @@ class IntelController extends Controller
     public function getNotesData(int $character_id)
     {
 
-        return Datatables::of(CharacterInfo::getNotes($character_id))
+        return app('DataTables')::of(CharacterInfo::getNotes($character_id))
             ->addColumn('actions', function ($row) {
 
                 return view('web::character.intel.partials.notesactions', compact('row'))

--- a/src/Http/Controllers/Character/KillmailController.php
+++ b/src/Http/Controllers/Character/KillmailController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Character;
 
 use Seat\Services\Repositories\Character\Killmails;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class KillmailController.
@@ -56,7 +55,7 @@ class KillmailController extends Controller
 
         $killmails = $this->getCharacterKillmails($character_id, false);
 
-        return Datatables::of($killmails)
+        return app('DataTables')::of($killmails)
             ->editColumn('character_name', function ($row) {
 
                 return view('web::partials.killmailcharacter', compact('row'))

--- a/src/Http/Controllers/Character/MailController.php
+++ b/src/Http/Controllers/Character/MailController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Character;
 
 use Seat\Services\Repositories\Character\Mail;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class MailController.
@@ -56,7 +55,7 @@ class MailController extends Controller
 
         $mail = $this->getCharacterMail($character_id, false);
 
-        return Datatables::of($mail)
+        return app('DataTables')::of($mail)
             ->editColumn('from', function ($row) {
 
                 return view('web::character.partials.mailsendername', compact('row'))

--- a/src/Http/Controllers/Character/MarketController.php
+++ b/src/Http/Controllers/Character/MarketController.php
@@ -25,7 +25,6 @@ namespace Seat\Web\Http\Controllers\Character;
 use Seat\Services\Repositories\Character\Market;
 use Seat\Services\Repositories\Eve\EveRepository;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class MarketController.
@@ -58,7 +57,7 @@ class MarketController extends Controller
 
         $orders = $this->getCharacterMarketOrders($character_id, false);
 
-        return Datatables::of($orders)
+        return app('DataTables')::of($orders)
             ->addColumn('bs', function ($row) {
 
                 return view('web::partials.marketbuysell', compact('row'))

--- a/src/Http/Controllers/Character/WalletController.php
+++ b/src/Http/Controllers/Character/WalletController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Character;
 
 use Seat\Services\Repositories\Character\Wallet;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class WalletController.
@@ -55,7 +54,7 @@ class WalletController extends Controller
 
         $journal = $this->getCharacterWalletJournal($character_id, false);
 
-        return Datatables::of($journal)
+        return app('DataTables')::of($journal)
             ->editColumn('ref_type', function ($row) {
 
                 return view('web::partials.journaltranstype', compact('row'))
@@ -149,7 +148,7 @@ class WalletController extends Controller
 
         $transactions = $this->getCharacterWalletTransactions($character_id, false);
 
-        return Datatables::of($transactions)
+        return app('DataTables')::of($transactions)
             ->editColumn('is_buy', function ($row) {
 
                 return view('web::partials.transactiontype', compact('row'))

--- a/src/Http/Controllers/Configuration/SecurityController.php
+++ b/src/Http/Controllers/Configuration/SecurityController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Configuration;
 
 use Seat\Services\Repositories\Configuration\SecurityRepository;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class SecurityController.
@@ -52,7 +51,7 @@ class SecurityController extends Controller
 
         $logs = $this->getAllSecurityLogs();
 
-        return Datatables::of($logs)
+        return app('DataTables')::of($logs)
             ->editColumn('user', function ($row) {
 
                 if ($row->user)

--- a/src/Http/Controllers/Corporation/ContractsController.php
+++ b/src/Http/Controllers/Corporation/ContractsController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 
 use Seat\Services\Repositories\Corporation\Contracts;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class ContractsController.
@@ -55,7 +54,7 @@ class ContractsController extends Controller
 
         $contracts = $this->getCorporationContracts($corporation_id, false);
 
-        return Datatables::of($contracts)
+        return app('DataTables')::of($contracts)
             ->editColumn('issuer_id', function ($row) {
 
                 return view('web::partials.contractissuer', compact('row'))

--- a/src/Http/Controllers/Corporation/CorporationsController.php
+++ b/src/Http/Controllers/Corporation/CorporationsController.php
@@ -25,7 +25,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Services\Repositories\Corporation\Corporation;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class CorporationsController.
@@ -53,7 +52,7 @@ class CorporationsController extends Controller
 
         $corporations = $this->getAllCorporationsWithAffiliationsAndFilters();
 
-        return Datatables::of($corporations)
+        return app('DataTables')::of($corporations)
             // Edit some columns to include links and icons
             ->editColumn('name', function ($row) {
 

--- a/src/Http/Controllers/Corporation/IndustryController.php
+++ b/src/Http/Controllers/Corporation/IndustryController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 
 use Seat\Services\Repositories\Corporation\Industry;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class IndustryController.
@@ -55,7 +54,7 @@ class IndustryController extends Controller
 
         $jobs = $this->getCorporationIndustry($corporation_id, false);
 
-        return Datatables::of($jobs)
+        return app('DataTables')::of($jobs)
             ->editColumn('installerName', function ($row) {
 
                 return view('web::partials.industryinstaller', compact('row'))

--- a/src/Http/Controllers/Corporation/KillmailsController.php
+++ b/src/Http/Controllers/Corporation/KillmailsController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 
 use Seat\Services\Repositories\Corporation\Killmails;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class KillmailsController.
@@ -55,7 +54,7 @@ class KillmailsController extends Controller
 
         $killmails = $this->getCorporationKillmails($corporation_id, false);
 
-        return Datatables::of($killmails)
+        return app('DataTables')::of($killmails)
             ->editColumn('character_name', function ($row) {
 
                 return view('web::partials.killmailcharacter', compact('row'))

--- a/src/Http/Controllers/Corporation/MarketController.php
+++ b/src/Http/Controllers/Corporation/MarketController.php
@@ -25,7 +25,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 use Seat\Services\Repositories\Corporation\Market;
 use Seat\Services\Repositories\Eve\EveRepository;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Facades\Datatables;
 
 /**
  * Class MarketController.
@@ -57,7 +56,7 @@ class MarketController extends Controller
 
         $orders = $this->getCorporationMarketOrders($corporation_id, false);
 
-        return Datatables::of($orders)
+        return app('DataTables')::of($orders)
             ->addColumn('bs', function ($row) {
 
                 return view('web::partials.marketbuysell', compact('row'))

--- a/src/Http/Controllers/Corporation/WalletController.php
+++ b/src/Http/Controllers/Corporation/WalletController.php
@@ -24,7 +24,6 @@ namespace Seat\Web\Http\Controllers\Corporation;
 
 use Seat\Services\Repositories\Corporation\Wallet;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class WalletController.
@@ -56,7 +55,7 @@ class WalletController extends Controller
 
         $journal = $this->getCorporationWalletJournal($corporation_id, false);
 
-        return Datatables::of($journal)
+        return app('DataTables')::of($journal)
             ->editColumn('ref_type', function ($row) {
 
                 return view('web::partials.journaltranstype', compact('row'))
@@ -105,7 +104,7 @@ class WalletController extends Controller
 
         $transactions = $this->getCorporationWalletTransactions($corporation_id, false);
 
-        return Datatables::of($transactions)
+        return app('DataTables')::of($transactions)
             ->editColumn('is_buy', function ($row) {
 
                 return view('web::partials.transactiontype', compact('row'))

--- a/src/Http/Controllers/Support/SearchController.php
+++ b/src/Http/Controllers/Support/SearchController.php
@@ -26,7 +26,6 @@ use Illuminate\Http\Request;
 use Seat\Eveapi\Models\Mail\MailHeader;
 use Seat\Services\Search\Search;
 use Seat\Web\Http\Controllers\Controller;
-use Yajra\Datatables\Datatables;
 
 /**
  * Class SearchController.
@@ -60,7 +59,7 @@ class SearchController extends Controller
 
         $characters = $this->doSearchCharacters();
 
-        return Datatables::of($characters)
+        return app('DataTables')::of($characters)
             ->editColumn('name', function ($row) {
 
                 return view('web::search.partials.charactername', compact('row'))
@@ -85,7 +84,7 @@ class SearchController extends Controller
 
         $corporations = $this->doSearchCorporations();
 
-        return Datatables::of($corporations)
+        return app('DataTables')::of($corporations)
             ->editColumn('name', function ($row) {
 
                 return view('web::search.partials.corporationname', compact('row'))
@@ -114,7 +113,7 @@ class SearchController extends Controller
 
         $mail = $this->doSearchCharacterMail();
 
-        return Datatables::of($mail)
+        return app('DataTables')::of($mail)
             ->editColumn('from', function ($row) {
 
                 return view('web::character.partials.mailsendername', compact('row'))
@@ -153,7 +152,7 @@ class SearchController extends Controller
 
         $assets = $this->doSearchCharacterAssets();
 
-        return Datatables::of($assets)
+        return app('DataTables')::of($assets)
             ->editColumn('characterName', function ($row) {
 
                 return view('web::search.partials.charactername', compact('row'))
@@ -178,7 +177,7 @@ class SearchController extends Controller
 
         $skills = $this->doSearchCharacterSkills();
 
-        return Datatables::of($skills)
+        return app('DataTables')::of($skills)
             ->editColumn('character_name', function ($row) {
 
                 return view('web::search.partials.charactername', compact('row'))

--- a/src/Http/Routes/Configuration/User.php
+++ b/src/Http/Routes/Configuration/User.php
@@ -25,6 +25,11 @@ Route::get('/', [
     'uses' => 'UserController@getAll',
 ]);
 
+Route::get('/users/data', [
+    'as'   => 'configuration.users.data',
+    'uses' => 'UserController@getUsersData',
+]);
+
 Route::post('/update', [
     'as'   => 'configuration.access.users.update',
     'uses' => 'UserController@updateUser',

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Auth\Events\Login as LoginEvent;
 use Illuminate\Auth\Events\Logout as LogoutEvent;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Horizon\Horizon;
 use Laravel\Socialite\SocialiteManager;
@@ -35,7 +36,6 @@ use Seat\Web\Events\Attempt;
 use Seat\Web\Events\Login;
 use Seat\Web\Events\Logout;
 use Seat\Web\Events\SecLog;
-use Seat\Web\Events\Security;
 use Seat\Web\Extentions\EveOnlineProvider;
 use Seat\Web\Http\Composers\CharacterMenu;
 use Seat\Web\Http\Composers\CharacterSummary;
@@ -52,7 +52,6 @@ use Seat\Web\Http\Middleware\Bouncer\KeyBouncer;
 use Seat\Web\Http\Middleware\Locale;
 use Seat\Web\Http\Middleware\RegistrationAllowed;
 use Seat\Web\Http\Middleware\Requirements;
-use Validator;
 
 /**
  * Class EveapiServiceProvider.
@@ -336,7 +335,7 @@ class WebServiceProvider extends ServiceProvider
      * Currently this consists of:
      *  - PragmaRX\Google2FA
      *  - Laravel\Socialite
-     *  - Yajra\Datatables
+     *  - Yajra\DataTables
      */
     public function register_services()
     {
@@ -361,21 +360,9 @@ class WebServiceProvider extends ServiceProvider
 
         // Register the datatables package! Thanks
         //  https://laracasts.com/discuss/channels/laravel/register-service-provider-and-facade-within-service-provider
-        $this->app->register('Yajra\Datatables\DatatablesServiceProvider');
+        $this->app->register('Yajra\DataTables\DataTablesServiceProvider');
         $loader = AliasLoader::getInstance();
-        $loader->alias('Datatables', 'Yajra\Datatables\Facades\Datatables');
-
-        // Register the Supervisor RPC helper into the IoC
-        $this->app->singleton('supervisor', function () {
-
-            return new Supervisor(
-                config('web.supervisor.name'),
-                config('web.supervisor.rpc.address'),
-                config('web.supervisor.rpc.username'),
-                config('web.supervisor.rpc.password'),
-                (int) config('web.supervisor.rpc.port')
-            );
-        });
+        $loader->alias('DataTables', 'Yajra\DataTables\Facades\DataTables');
 
     }
 }

--- a/src/resources/assets/css/seat.css
+++ b/src/resources/assets/css/seat.css
@@ -33,71 +33,13 @@ img.eve-icon.xxlarge-icon {
 }
 
 /*
- * Profile Drop Down
+ * Bootstrap 4 helpers
  */
-
-ul.dropdown-menu {
-    padding: 0;
-}
-
-ul.dropdown-menu > li.user-character:first-child {
-    border-top: solid 1px #eee;
-}
-
-ul.dropdown-menu > li.user-character {
-    margin-top: 0;
-    border-bottom: 1px solid #eee;
-}
-
-.skin-blue ul.dropdown-menu > li.user-character.active a {
-    background-color: #3c8dbc;
-}
-
-.skin-black ul.dropdown-menu > li.user-character.active a {
-    background-color: #6a6a6a;
-}
-
-.skin-green ul.dropdown-menu > li.user-character.active a {
-    background-color: #00a65a;
-}
-
-.skin-purple ul.dropdown-menu > li.user-character.active a {
-    background-color: #605ca8;
-}
-
-.skin-red ul.dropdown-menu > li.user-character.active a {
-    background-color: #dd4b39;
-}
-
-.skin-yellow ul.dropdown-menu > li.user-character.active a {
-    background-color: #f39c12;
-}
-
-ul.dropdown-menu > li.user-character a .media-left {
-    vertical-align: middle;
-}
-
-ul.dropdown-menu > li.user-character a h4.media-heading {
-    margin-bottom: 1px;
-}
-
-ul.dropdown-menu li.user-character.new-character {
-    border-bottom: 1px solid #f4f4f4;
-}
-
-ul.dropdown-menu li.user-character.new-character a h3 {
-    margin-top: 7px;
-    margin-bottom: 7px;
-}
-
-.border-0 {
-    border: none;
-}
-
-.margin-0 {
-    margin: 0;
-}
 
 .bg-none {
     background: none;
+}
+
+.align-middle {
+    vertical-align: middle !important;
 }

--- a/src/resources/views/configuration/users/list.blade.php
+++ b/src/resources/views/configuration/users/list.blade.php
@@ -8,164 +8,52 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">
-        {{ trans_choice('web::seat.group', count($groups)) }}
+        {{ trans_choice('web::seat.group', count($group_counter)) }}
       </h3>
     </div>
     <div class="panel-body">
 
-      <table class="table datatable compact table-condensed table-hover table-responsive">
+      <table class="table compact table-condensed table-hover table-responsive" id="users-list">
         <thead>
-        <tr>
-          <th>{{ trans('web::seat.main_character') }}</th>
-          <th>{{ trans_choice('web::seat.role', 2) }}</th>
-          <th>{{ trans('web::seat.email') }}</th>
-          <th>{{ trans_choice('web::seat.character', 2) }}</th>
-        </tr>
-        </thead>
-
-        <tbody>
-
-        @foreach($groups->sortBy(function($item, $key) { return strtolower(optional($item->main_character)->name); }) as $group)
-
           <tr>
-            <td class="align-middle text-center">
-              {!! img('character', optional($group->main_character)->character_id, 64, ['class' => 'img-circle eve-icon medium-icon']) !!}
-              <span class="users-list-name">{{ optional($group->main_character)->name }}</span>
-            </td>
-            <td class="align-middle text-center">
-              @if(count($group->roles) > 0)
-                <ul class="list-unstyled">
-                  @foreach($group->roles as $role)
-                    <li>{{ $role->title }}</li>
-                  @endforeach
-                </ul>
-              @else
-                <span class="label label-warning">No Roles</span>
-              @endif
-            </td>
-            <td class="align-middle text-center">{{ $group->email }}</td>
-            <td>
-
-              <ul class="list-group no-margin">
-                @foreach($group->users->sortBy(function($item) { return strtolower($item->name); }) as $user)
-
-                  <li class="list-group-item no-border bg-none">
-                    <div class="media">
-                      <div class="media-left media-middle hidden-xs hidden-sm">
-                        <!-- user avatar -->
-                        {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon medium-icon media-object', 'alt' => $user->name], false) !!}
-                      </div>
-                      <div class="media-body">
-                        <!-- user information -->
-                        <div class="col-xs-12 col-sm-6 col-md-6">
-                          <ul class="list-unstyled">
-                            <li>
-                              <span class="users-list-name">
-                                <!-- token status -->
-                                @if($user->refresh_token)
-                                  <i class="fa fa-check text-success" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.valid_token') }}"></i>
-                                @else
-                                  <i class="fa fa-exclamation-triangle text-danger" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.invalid_token') }}"></i>
-                                @endif
-                                {{ $user->name }}
-                              </span>
-                            </li>
-                            <li>(last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})</li>
-                            <li class="hidden-sm hidden-md hidden-lg">
-                              <!-- actions -->
-                              <div class="btn-group btn-group-justified btn-group-sm" role="group">
-
-                                  @if(auth()->user()->id != $user->id)
-                                    <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
-                                       title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
-                                      <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
-                                    </a>
-
-                                  @else
-                                    <a class="btn disabled btn-link">
-                                      <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
-                                    </a>
-                                  @endif
-
-                                  <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
-                                     title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
-                                    <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
-                                  </a>
-
-                                  @if(auth()->user()->id != $user->id)
-                                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                                       title="{{ trans('web::seat.delete') }}"
-                                       class="confirmlink btn btn-danger">
-                                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                                    </a>
-                                  @else
-                                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                                       title="{{ trans('web::seat.delete') }}"
-                                       class="confirmlink disabled btn-danger btn">
-                                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                                    </a>
-                                  @endif
-
-                                </div>
-                            </li>
-                          </ul>
-                        </div>
-                        <!-- actions -->
-                        <div class="hidden-xs col-sm-6 col-md-6">
-                          <div class="btn-group-vertical btn-group-xs pull-right" role="group">
-
-                            @if(auth()->user()->id != $user->id)
-                              <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
-                                 title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
-                                <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
-                              </a>
-
-                            @else
-                              <a class="btn disabled btn-link">
-                                <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
-                              </a>
-                            @endif
-
-                            <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
-                               title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
-                              <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
-                            </a>
-
-                            @if(auth()->user()->id != $user->id)
-                              <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                                 title="{{ trans('web::seat.delete') }}"
-                                 class="confirmlink btn btn-danger">
-                                <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                              </a>
-                            @else
-                              <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                                 title="{{ trans('web::seat.delete') }}"
-                                 class="confirmlink disabled btn-danger btn">
-                                <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                              </a>
-                            @endif
-
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </li>
-                @endforeach
-              </ul>
-
-            </td>
+            <th>{{ trans('web::seat.main_character') }}</th>
+            <th>{{ trans_choice('web::seat.role', 2) }}</th>
+            <th>{{ trans('web::seat.email') }}</th>
+            <th>{{ trans_choice('web::seat.character', 2) }}</th>
           </tr>
-
-        @endforeach
-        </tbody>
+        </thead>
+        <tbody></tbody>
       </table>
 
     </div>
     <div class="panel-footer">
-      <b>{{ count($groups) }}</b> {{ trans_choice('web::seat.group', count($groups)) }} |
-      <b>{{ $groups->map(function($r) { return $r->users->count(); })->sum() }}</b> {{ trans_choice('web::seat.user', 2) }}
+      <b>{{ $group_counter }}</b> {{ trans_choice('web::seat.group', count($group_counter)) }} |
+      <b>{{ $user_counter }}</b> {{ trans_choice('web::seat.user', 2) }}
     </div>
 
   </div>
 
 @stop
+
+@push('javascript')
+
+  <script>
+
+      $(function () {
+          $('table#users-list').DataTable({
+              processing      : true,
+              serverSide      : true,
+              ajax            : '{{ route('configuration.users.data') }}',
+              columns         : [
+                  {data: 'main_character', name: 'main_character', className: 'align-middle text-center'},
+                  {data: 'roles', name: 'roles', className: 'align-middle text-center'},
+                  {data: 'email', name: 'email', className: 'align-middle text-center'},
+                  {data: 'users', name: 'users'}
+              ],
+              dom             : '<"row"<"col-sm-6"l><"col-sm-6"f>><"row"<"col-sm-6"i><"col-sm-6"p>>rt<"row"<"col-sm-6"i><"col-sm-6"p>><"row"<"col-sm-6"l><"col-sm-6"f>>',
+              order           : [[0, "asc"]]
+          });
+      });
+
+  </script>
+@endpush

--- a/src/resources/views/configuration/users/list.blade.php
+++ b/src/resources/views/configuration/users/list.blade.php
@@ -28,11 +28,11 @@
         @foreach($groups->sortBy(function($item, $key) { return strtolower(optional($item->main_character)->name); }) as $group)
 
           <tr>
-            <td>
+            <td class="align-middle text-center">
               {!! img('character', optional($group->main_character)->character_id, 64, ['class' => 'img-circle eve-icon medium-icon']) !!}
-              <span>{{ optional($group->main_character)->name }}</span>
+              <span class="users-list-name">{{ optional($group->main_character)->name }}</span>
             </td>
-            <td>
+            <td class="align-middle text-center">
               @if(count($group->roles) > 0)
                 <ul class="list-unstyled">
                   @foreach($group->roles as $role)
@@ -40,16 +40,16 @@
                   @endforeach
                 </ul>
               @else
-                No Roles
+                <span class="label label-warning">No Roles</span>
               @endif
             </td>
-            <td>{{ $group->email }}</td>
+            <td class="align-middle text-center">{{ $group->email }}</td>
             <td>
 
-              <ul class="list-group">
+              <ul class="list-group no-margin">
                 @foreach($group->users->sortBy(function($item) { return strtolower($item->name); }) as $user)
 
-                  <li class="list-group-item">
+                  <li class="list-group-item no-border bg-none">
 
                     <div class="container-fluid">
                       <div class="row">
@@ -67,7 +67,7 @@
                         @endif
 
                       <!-- user information -->
-                        {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+                        {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon small-icon', 'alt' => $user->name]) !!}
                         {{ $user->name }}
                         (last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})
                         <!-- actions -->

--- a/src/resources/views/configuration/users/list.blade.php
+++ b/src/resources/views/configuration/users/list.blade.php
@@ -50,65 +50,109 @@
                 @foreach($group->users->sortBy(function($item) { return strtolower($item->name); }) as $user)
 
                   <li class="list-group-item no-border bg-none">
+                    <div class="media">
+                      <div class="media-left media-middle hidden-xs hidden-sm">
+                        <!-- user avatar -->
+                        {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon medium-icon media-object', 'alt' => $user->name], false) !!}
+                      </div>
+                      <div class="media-body">
+                        <!-- user information -->
+                        <div class="col-xs-12 col-sm-6 col-md-6">
+                          <ul class="list-unstyled">
+                            <li>
+                              <!-- token status -->
+                              @if($user->refresh_token)
+                                <button data-toggle="tooltip" title="{{ trans('web::seat.valid_token') }}"
+                                        class="btn btn-xs btn-link">
+                                  <i class="fa fa-check text-success"></i>
+                                </button>
+                              @else
+                                <button data-toggle="tooltip" title="{{ trans('web::seat.invalid_token') }}"
+                                        class="btn btn-xs btn-link">
+                                  <i class="fa fa-exclamation-triangle text-danger"></i>
+                                </button>
+                              @endif
+                              <span>{{ $user->name }}</span>
+                            </li>
+                            <li>(last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})</li>
+                            <li class="hidden-sm hidden-md hidden-lg">
+                              <!-- actions -->
+                              <div class="btn-group btn-group-justified btn-group-sm" role="group">
 
-                    <div class="container-fluid">
-                      <div class="row">
-                        <!-- token status -->
-                        @if($user->refresh_token)
-                          <button data-toggle="tooltip" title="{{ trans('web::seat.valid_token') }}"
-                                  class="btn btn-xs btn-link">
-                            <i class="fa fa-check text-success"></i>
-                          </button>
-                        @else
-                          <button data-toggle="tooltip" title="{{ trans('web::seat.invalid_token') }}"
-                                  class="btn btn-xs btn-link">
-                            <i class="fa fa-exclamation-triangle text-danger"></i>
-                          </button>
-                        @endif
+                                  @if(auth()->user()->id != $user->id)
+                                    <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
+                                       title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
+                                      <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
+                                    </a>
 
-                      <!-- user information -->
-                        {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon small-icon', 'alt' => $user->name]) !!}
-                        {{ $user->name }}
-                        (last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})
+                                  @else
+                                    <a class="btn disabled btn-link">
+                                      <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
+                                    </a>
+                                  @endif
+
+                                  <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
+                                     title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
+                                    <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
+                                  </a>
+
+                                  @if(auth()->user()->id != $user->id)
+                                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                                       title="{{ trans('web::seat.delete') }}"
+                                       class="confirmlink btn btn-danger">
+                                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                                    </a>
+                                  @else
+                                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                                       title="{{ trans('web::seat.delete') }}"
+                                       class="confirmlink disabled btn-danger btn">
+                                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                                    </a>
+                                  @endif
+
+                                </div>
+                            </li>
+                          </ul>
+                        </div>
                         <!-- actions -->
-                        <div class="btn-group btn-group-xs pull-right" role="group">
+                        <div class="hidden-xs col-sm-6 col-md-6">
+                          <div class="btn-group-vertical btn-group-xs pull-right" role="group">
 
-                          @if(auth()->user()->id != $user->id)
-                            <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
-                               title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
-                              <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
+                            @if(auth()->user()->id != $user->id)
+                              <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
+                                 title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
+                                <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
+                              </a>
+
+                            @else
+                              <a class="btn disabled btn-link">
+                                <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
+                              </a>
+                            @endif
+
+                            <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
+                               title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
+                              <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
                             </a>
 
-                          @else
-                            <a class="btn disabled btn-link">
-                              <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
-                            </a>
-                          @endif
+                            @if(auth()->user()->id != $user->id)
+                              <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                                 title="{{ trans('web::seat.delete') }}"
+                                 class="confirmlink btn btn-danger">
+                                <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                              </a>
+                            @else
+                              <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                                 title="{{ trans('web::seat.delete') }}"
+                                 class="confirmlink disabled btn-danger btn">
+                                <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                              </a>
+                            @endif
 
-                          <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
-                             title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
-                            <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
-                          </a>
-
-                          @if(auth()->user()->id != $user->id)
-                            <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                               title="{{ trans('web::seat.delete') }}"
-                               class="confirmlink btn btn-danger">
-                              <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                            </a>
-                          @else
-                            <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
-                               title="{{ trans('web::seat.delete') }}"
-                               class="confirmlink disabled btn-danger btn">
-                              <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
-                            </a>
-                          @endif
-
+                          </div>
                         </div>
                       </div>
-
                     </div>
-
                   </li>
                 @endforeach
               </ul>

--- a/src/resources/views/configuration/users/list.blade.php
+++ b/src/resources/views/configuration/users/list.blade.php
@@ -60,19 +60,15 @@
                         <div class="col-xs-12 col-sm-6 col-md-6">
                           <ul class="list-unstyled">
                             <li>
-                              <!-- token status -->
-                              @if($user->refresh_token)
-                                <button data-toggle="tooltip" title="{{ trans('web::seat.valid_token') }}"
-                                        class="btn btn-xs btn-link">
-                                  <i class="fa fa-check text-success"></i>
-                                </button>
-                              @else
-                                <button data-toggle="tooltip" title="{{ trans('web::seat.invalid_token') }}"
-                                        class="btn btn-xs btn-link">
-                                  <i class="fa fa-exclamation-triangle text-danger"></i>
-                                </button>
-                              @endif
-                              <span>{{ $user->name }}</span>
+                              <span class="users-list-name">
+                                <!-- token status -->
+                                @if($user->refresh_token)
+                                  <i class="fa fa-check text-success" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.valid_token') }}"></i>
+                                @else
+                                  <i class="fa fa-exclamation-triangle text-danger" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.invalid_token') }}"></i>
+                                @endif
+                                {{ $user->name }}
+                              </span>
                             </li>
                             <li>(last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})</li>
                             <li class="hidden-sm hidden-md hidden-lg">

--- a/src/resources/views/configuration/users/partials/characters.blade.php
+++ b/src/resources/views/configuration/users/partials/characters.blade.php
@@ -1,0 +1,103 @@
+<ul class="list-group no-margin">
+  @foreach($row->users->sortBy(function($item) { return strtolower($item->name); }) as $user)
+    <li class="list-group-item no-border bg-none">
+      <div class="media">
+        <div class="media-left media-middle hidden-xs hidden-sm">
+          <!-- user avatar -->
+          {!! img('character', $user->id, 64, ['class' => 'img-circle eve-icon medium-icon media-object', 'alt' => $user->name], false) !!}
+        </div>
+        <div class="media-body">
+          <!-- user information -->
+          <div class="col-xs-12 col-sm-6 col-md-6">
+            <ul class="list-unstyled">
+              <li>
+                <span class="users-list-name">
+                  <!-- token status -->
+                  @if($user->refresh_token)
+                    <i class="fa fa-check text-success" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.valid_token') }}"></i>
+                  @else
+                    <i class="fa fa-exclamation-triangle text-danger" data-toggle="tooltip" data-placement="top" title="{{ trans('web::seat.invalid_token') }}"></i>
+                  @endif
+                  {{ $user->name }}
+                </span>
+              </li>
+              <li>(last logged in {{ human_diff($user->last_login) }} from {{ $user->last_login_source }})</li>
+              <li class="hidden-sm hidden-md hidden-lg">
+                <!-- actions -->
+                <div class="btn-group btn-group-justified btn-group-sm" role="group">
+
+                  @if(auth()->user()->id != $user->id)
+                    <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
+                      title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
+                      <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
+                    </a>
+                  @else
+                    <a class="btn disabled btn-link">
+                      <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
+                    </a>
+                  @endif
+
+                  <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
+                    title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
+                    <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
+                  </a>
+
+                  @if(auth()->user()->id != $user->id)
+                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                      title="{{ trans('web::seat.delete') }}"
+                      class="confirmlink btn btn-danger">
+                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                    </a>
+                  @else
+                    <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                      title="{{ trans('web::seat.delete') }}"
+                      class="confirmlink disabled btn-danger btn">
+                      <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                    </a>
+                  @endif
+
+                </div>
+              </li>
+            </ul>
+          </div>
+          <!-- actions -->
+          <div class="hidden-xs col-sm-6 col-md-6">
+            <div class="btn-group-vertical btn-group-xs pull-right" role="group">
+
+              @if(auth()->user()->id != $user->id)
+                <a href="{{ route('configuration.users.impersonate', ['user_id' => $user->id]) }}"
+                  title="{{ trans('web::seat.impersonate') }}" class="btn btn-default">
+                  <i class="fa fa-user-secret"></i> {{ trans('web::seat.impersonate') }}
+                </a>
+              @else
+                <a class="btn disabled btn-link">
+                  <i class="fa fa-user"></i> <em class="text-danger">(This is you!)</em>
+                </a>
+              @endif
+
+              <a href="{{ route('configuration.users.edit', ['user_id' => $user->id]) }}"
+                title="{{ trans('web::seat.edit') }}" class="btn btn-warning">
+                <i class="fa fa-pencil"></i> {{ trans('web::seat.edit') }}
+              </a>
+
+              @if(auth()->user()->id != $user->id)
+                <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                  title="{{ trans('web::seat.delete') }}"
+                  class="confirmlink btn btn-danger">
+                  <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                </a>
+              @else
+                <a href="{{ route('configuration.users.delete', ['user_id' => $user->id]) }}"
+                  title="{{ trans('web::seat.delete') }}"
+                  class="confirmlink disabled btn-danger btn">
+                  <i class="fa fa-times"></i> {{ trans('web::seat.delete') }}
+                </a>
+              @endif
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  @endforeach
+</ul>

--- a/src/resources/views/configuration/users/partials/main_character.blade.php
+++ b/src/resources/views/configuration/users/partials/main_character.blade.php
@@ -1,0 +1,2 @@
+{!! img('character', optional($row->main_character)->character_id, 64, ['class' => 'img-circle eve-icon medium-icon'], false) !!}
+<span class="users-list-name">{{ optional($row->main_character)->name }}</span>

--- a/src/resources/views/configuration/users/partials/roles.blade.php
+++ b/src/resources/views/configuration/users/partials/roles.blade.php
@@ -1,0 +1,9 @@
+@if(count($row->roles) > 0)
+  <ul class="list-unstyled">
+    @foreach($row->roles as $role)
+      <li>{{ $role->title }}</li>
+    @endforeach
+  </ul>
+@else
+  <span class="label label-warning">No Roles</span>
+@endif


### PR DESCRIPTION
This is an improvement of eveseat/web#193 including paginate table.
It's include dependencies update (bumping datatable to 8x according to specs : https://github.com/yajra/laravel-datatables/tree/8.0#laravel-version-compatibility) which is required due to missing hotfix into 6x.

Redesign the user list to something more ergonomic and shining.
- Large button inline for small devices; small button vertical stacked for large devices.
- Hiding character avatar on small devices (except main one)
- Using a list to display character information

![ui-redesign-lg](https://user-images.githubusercontent.com/648753/42132925-275a2918-7d21-11e8-98af-4e87e1733ab9.png)
![ui-redesign-md](https://user-images.githubusercontent.com/648753/42132920-23d1001e-7d21-11e8-8b0d-8982bc186d37.png)
![ui-redesign-sm](https://user-images.githubusercontent.com/648753/42132921-24b495e0-7d21-11e8-9449-23f8b3ca350a.png)
![ui-redesign-xs](https://user-images.githubusercontent.com/648753/42132923-25d618ae-7d21-11e8-8acc-e28faacb2d65.png)