### PR TITLE
fix(corporation structures): Fix table sort on offline column

### DIFF
--- a/src/resources/views/corporation/structures.blade.php
+++ b/src/resources/views/corporation/structures.blade.php
@@ -42,10 +42,10 @@
                 <td>
                   {{ ucfirst(str_replace('_', ' ', $structure->state)) }}
                 </td>
-                <td>
-            <span data-toggle="tooltip" title="" data-original-title="{{ $structure->fuel_expires }}">
-              {{ human_diff($structure->fuel_expires) }}
-            </span>
+                <td data-sort="{{ $structure->fuel_expires }}">
+                    <span data-toggle="tooltip" title="" data-original-title="{{ $structure->fuel_expires }}">
+                      {{ human_diff($structure->fuel_expires) }}
+                    </span>
                 </td>
                 <td>
             <span data-toggle="tooltip" title=""


### PR DESCRIPTION
Add a data-sort attribute with the full timestamp in order to fix sort
on offline estimated time.

Closes eveseat/seat#413