### PR TITLE
feat(contacts): Bump corporation and character contact endpoint to v2

### DIFF
--- a/src/resources/views/character/contacts.blade.php
+++ b/src/resources/views/character/contacts.blade.php
@@ -59,8 +59,7 @@
               </span>
             </td>
             <td>
-              {{ $labels->filter(function($item) use ($contact) {
-                return $item->label_id & $contact->label_id; })->implode('label_name', ', ') }}
+              {{ $labels->whereIn('label_id', $contact->label_ids)->implode('label_name', ', ') }}
             </td>
             <td>
               @if (!in_array($contact->contact_type, ['corporation', 'alliance']))

--- a/src/resources/views/corporation/contacts.blade.php
+++ b/src/resources/views/corporation/contacts.blade.php
@@ -48,8 +48,7 @@
               </span>
             </td>
             <td>
-              {{ $labels->filter(function($item) use ($contact) {
-                 return $item->label_id & $contact->label_id; })->implode('label_name', ', ') }}
+              {{ $labels->whereIn('label_id', $contact->label_ids)->implode('label_name', ', ') }}
             </td>
             <td>
               @if (!in_array($contact->contact_type, ['corporation', 'alliance']))


### PR DESCRIPTION
Use label_ids field directly as a filter since v2 endpoint is returning an array of ids instead
concatenated binary and.

Closes eveseat/seat#368