### PR TITLE
fix(jump clones): Display name of player structure

### DIFF
--- a/src/resources/views/character/sheet.blade.php
+++ b/src/resources/views/character/sheet.blade.php
@@ -130,11 +130,17 @@
                 <ul>
 
                   @foreach($jump_clones as $clone)
-                    @if(!is_null($clone->location))
-                      <li>Located at <b>{{ $clone->location->stationName }}</b></li>
-                    @else
-                      <li>Location is unknown</li>
-                    @endif
+                    <li>
+                        @if(! is_null($clone->name))
+                        ({{ $clone->name }})
+                        @endif
+
+                        @if(! is_null($clone->location))
+                        Located at <b>{{ $clone->location->name }}</b>
+                        @else
+                        Location is unknown
+                        @endif
+                    </li>
                   @endforeach
 
                 </ul>


### PR DESCRIPTION
Fix character jump clone model relation to target universe structure instead StaStation when
location_type field has a value of structure.

Closes eveseat/seat#397