### PR TITLE
fix(industry jobs): Fix datatable search

### DIFF
--- a/src/Http/Controllers/Character/IndustryController.php
+++ b/src/Http/Controllers/Character/IndustryController.php
@@ -61,7 +61,7 @@ class IndustryController extends Controller
                 return view('web::partials.industryinstaller', compact('row'))
                     ->render();
             })
-            ->editColumn('solarSystemName', function ($row) {
+            ->editColumn('facilityName', function ($row) {
 
                 return view('web::partials.industrysystem', compact('row'))
                     ->render();

--- a/src/Http/Controllers/Corporation/IndustryController.php
+++ b/src/Http/Controllers/Corporation/IndustryController.php
@@ -56,12 +56,12 @@ class IndustryController extends Controller
         $jobs = $this->getCorporationIndustry($corporation_id, false);
 
         return Datatables::of($jobs)
-            ->editColumn('installerName', function ($row) {
+            ->editColumn('installer_id', function ($row) {
 
                 return view('web::partials.industryinstaller', compact('row'))
                     ->render();
             })
-            ->editColumn('solarSystemName', function ($row) {
+            ->editColumn('facilityName', function ($row) {
 
                 return view('web::partials.industrysystem', compact('row'))
                     ->render();

--- a/src/resources/views/character/industry.blade.php
+++ b/src/resources/views/character/industry.blade.php
@@ -28,7 +28,6 @@
         <thead>
         <tr>
           <th>{{ trans('web::seat.start') }}</th>
-          <th>{{ trans('web::seat.installer') }}</th>
           <th>{{ trans('web::seat.system') }}</th>
           <th>{{ trans('web::seat.activity') }}</th>
           <th>{{ trans_choice('web::seat.run', 2) }}</th>
@@ -54,14 +53,13 @@
         ajax            : '{{ route('character.view.industry.data', ['character_id' => $request->character_id]) }}',
         dom             : '<"row"<"col-sm-6"l><"col-sm-6"f>><"row"<"col-sm-6"i><"col-sm-6"p>><"row"<"col-sm-12"<"character-industry_filters">>><"row"<"col-sm-12"rt>><"row"<"col-sm-5"i><"col-sm-7"p>><"row"<"col-sm-6"l><"col-sm-6"f>>',
         columns         : [
-          {data: 'start_date', name: 'start_date', render: human_readable},
-          {data: 'installer_id', name: 'installer_id'},
-          {data: 'solarSystemName', name: 'solarSystemName'},
-          {data: 'activityName', name: 'activityName'},
-          {data: 'runs', name: 'runs'},
-          {data: 'blueprintTypeName', name: 'blueprintTypeName'},
-          {data: 'productTypeName', name: 'productTypeName'},
-          {data: 'status', name: 'status', visible: false}
+          {data: 'start_date', name: 'a.start_date', render: human_readable},
+          {data: 'facilityName', name: 'a.facility_id'},
+          {data: 'activityName', name: 'ramActivities.activityName'},
+          {data: 'runs', name: 'a.runs'},
+          {data: 'blueprintTypeName', name: 'blueprintType.TypeName'},
+          {data: 'productTypeName', name: 'productType.typeName'},
+          {data: 'status', name: 'a.status', visible: false}
         ],
         'fnDrawCallback': function () {
           $(document).ready(function () {
@@ -71,7 +69,7 @@
       });
 
       // initial filter
-      table.column(7)
+      table.columns(6)
           .search('[[:<:]]active[[:>:]]', true, false) // strict lookup
           .draw();
 
@@ -85,7 +83,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(6)
             .search('[[:<:]]active[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -98,7 +96,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(6)
             .search('[[:<:]]paused[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -111,7 +109,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(6)
             .search('[[:<:]]ready[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -124,7 +122,7 @@
         $(this).addClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.column(6)
             .search('[[:<:]]cancelled[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -137,7 +135,7 @@
         filterCancelled.removeClass('disabled');
         $(this).addClass('disabled');
 
-        table.column(7)
+        table.columns(6)
             .search('[[:<:]]delivered[[:>:]]|[[:<:]]reverted[[:>:]]', true, false) // strict lookup
             .draw();
       });

--- a/src/resources/views/corporation/industry.blade.php
+++ b/src/resources/views/corporation/industry.blade.php
@@ -35,7 +35,7 @@
 
 @push('javascript')
 
-  <script>
+  <script type="application/javascript">
 
     $(function () {
       var table = $('table#corporation-industry').DataTable({
@@ -44,24 +44,25 @@
         ajax            : '{{ route('corporation.view.industry.data', ['corporation_id' => $request->corporation_id]) }}',
         dom             : '<"row"<"col-sm-6"l><"col-sm-6"f>><"row"<"col-sm-6"i><"col-sm-6"p>><"row"<"col-sm-12"<"corporation-industry_filters">>><"row"<"col-sm-12"rt>><"row"<"col-sm-5"i><"col-sm-7"p>><"row"<"col-sm-6"l><"col-sm-6"f>>',
         columns         : [
-          {data: 'end_date', name: 'end_date', render: human_readable},
-          {data: 'installer_id', name: 'installer_id'},
-          {data: 'solarSystemName', name: 'solarSystemName'},
-          {data: 'activityName', name: 'activityName'},
-          {data: 'runs', name: 'runs'},
-          {data: 'blueprintTypeName', name: 'blueprintTypeName'},
-          {data: 'productTypeName', name: 'productTypeName'},
-          {data: 'status', name: 'status', visible: false}
+          {data: 'end_date', name: 'a.end_date', render: human_readable},
+          {data: 'installer_id', name: 'a.installer_id'},
+          {data: 'facilityName', name: 'a.facility_id'},
+          {data: 'activityName', name: 'ramActivities.activityName'},
+          {data: 'runs', name: 'a.runs'},
+          {data: 'blueprintTypeName', name: 'blueprintType.typeName'},
+          {data: 'productTypeName', name: 'productType.typeName'},
+          {data: 'status', name: 'a.status', visible: false}
         ],
-        "fnDrawCallback": function () {
+        'fnDrawCallback': function () {
           $(document).ready(function () {
-            $("img").unveil(100);
+            ids_to_names();
+            $('img').unveil(100);
           });
         }
       });
 
       // initial filter
-      table.column(7)
+      table.columns(7)
           .search('[[:<:]]active[[:>:]]', true, false) // strict lookup
           .draw();
 
@@ -75,7 +76,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(7)
             .search('[[:<:]]active[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -88,7 +89,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(7)
             .search('[[:<:]]paused[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -101,7 +102,7 @@
         filterCancelled.removeClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(7)
             .search('[[:<:]]ready[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -114,7 +115,7 @@
         $(this).addClass('disabled');
         filterHistory.removeClass('disabled');
 
-        table.column(7)
+        table.columns(7)
             .search('[[:<:]]cancelled[[:>:]]', true, false) // strict lookup
             .draw();
       });
@@ -127,7 +128,7 @@
         filterCancelled.removeClass('disabled');
         $(this).addClass('disabled');
 
-        table.column(7)
+        table.columns(7)
             .search('[[:<:]]delivered[[:>:]]|[[:<:]]reverted[[:>:]]', true, false) // strict lookup
             .draw();
       });

--- a/src/resources/views/includes/javascript/id-to-name.blade.php
+++ b/src/resources/views/includes/javascript/id-to-name.blade.php
@@ -18,7 +18,7 @@
           items.push(val);
     });
 
-    var items = $.unique(items);
+    items = $.unique(items);
 
     while (items.length > 0)
       arrays.push(items.splice(0, size));


### PR DESCRIPTION
Append table on column definition from both character and corporation industry datatable since
we're using more than a single table in our query. Yajra DT need table.field in order to build
proper query.

Also remove installer column from character industry jobs which is useless.

BREAKING CHANGE: eveseat/web#202