### PR TITLE
fix(mining ledger): Fix loading time issue due to prices eager-load

### DIFF
--- a/src/Http/Controllers/Character/MiningLedgerController.php
+++ b/src/Http/Controllers/Character/MiningLedgerController.php
@@ -23,6 +23,7 @@
 namespace Seat\Web\Http\Controllers\Character;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Seat\Services\Repositories\Character\MiningLedger;
 use Seat\Web\Http\Controllers\Controller;
@@ -45,17 +46,10 @@ class MiningLedgerController extends Controller
     public function getLedger(int $character_id): View
     {
 
-        $ledger = $this->getCharacterLedger($character_id)
-            ->sortByDesc('date')
-            ->groupBy('date', 'solar_system_id', 'type_id')
-            ->map(function ($row) {
-
-                $row->quantity = $row->sum('quantity');
-                $row->volumes = $row->sum('volumes');
-                $row->value = $row->sum('value');
-
-                return $row;
-            })->flatten();
+        $ledger = $this->getCharacterLedger($character_id, false)
+            ->addSelect(DB::raw('SUM(quantity) as quantity'), DB::raw('SUM(quantity * volume) as volumes'), DB::raw('SUM(quantity * adjusted_price) as amounts'))
+            ->groupBy('character_id', 'date', 'solar_system_id', 'type_id')
+            ->get();
 
         return view('web::character.mining-ledger', compact('ledger'));
     }
@@ -72,10 +66,10 @@ class MiningLedgerController extends Controller
     {
 
         $entries = $this->getCharacterLedger($character_id, false)
-            ->addSelect('time')
-            ->where('date', $date)
+            ->addSelect('time', 'quantity', DB::raw('(quantity * volume) as volumes'), DB::raw('(quantity * adjusted_price) as amounts'))
+            ->where('character_minings.date', $date)
             ->where('solar_system_id', $system_id)
-            ->where('type_id', $type_id)
+            ->where('character_minings.type_id', $type_id)
             ->get();
 
         return Datatables::of($entries)
@@ -94,7 +88,7 @@ class MiningLedgerController extends Controller
                 return view('web::partials.miningvolume', compact('row'))
                     ->render();
             })
-            ->addColumn('value', function ($row) {
+            ->editColumn('amounts', function ($row) {
 
                 return view('web::partials.miningvalue', compact('row'))
                     ->render();

--- a/src/Http/Controllers/Corporation/MiningLedgerController.php
+++ b/src/Http/Controllers/Corporation/MiningLedgerController.php
@@ -54,16 +54,7 @@ class MiningLedgerController extends Controller
 
         $ledgers = $this->getCorporationLedgers($corporation_id);
 
-        $entries = $this->getCorporationLedger($corporation_id, $year, $month)
-            ->groupBy('character_id')
-            ->map(function ($row) {
-
-                $row->quantity = $row->sum('quantity');
-                $row->volumes = $row->sum('volumes');
-                $row->value = $row->sum('value');
-
-                return $row;
-            });
+        $entries = $this->getCorporationLedger($corporation_id, $year, $month);
 
         return view('web::corporation.mining.ledger', compact('ledgers', 'entries'));
     }

--- a/src/resources/views/character/mining-ledger.blade.php
+++ b/src/resources/views/character/mining-ledger.blade.php
@@ -52,8 +52,7 @@
             </td>
             <td class="text-right" data-order="{{ $entry->quantity }}">{{ number($entry->quantity) }}</td>
             <td class="text-right" data-order="{{ $entry->volumes }}">{{ number($entry->volumes) }} m3</td>
-            <td class="text-right" data-order="{{ $entry->value }}">
-              {{ number($entry->value) }} ISK
+            <td class="text-right" data-order="{{ $entry->amounts }}">{{ number($entry->amounts) }} ISK
               <a href="#" class="btn btn-sm btn-link" data-toggle="modal" data-target="#detailed-ledger">
                 <i class="fa fa-cubes"></i>
               </a>
@@ -109,8 +108,8 @@
                 {data: 'time'},
                 {data: 'quantity'},
                 {data: 'volumes'},
-                {data: 'value'}
-              ],
+                {data: 'amounts'}
+              ]
             });
 
 

--- a/src/resources/views/corporation/mining/ledger.blade.php
+++ b/src/resources/views/corporation/mining/ledger.blade.php
@@ -42,24 +42,24 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach($entries as $character_id => $entry)
+                    @foreach($entries as $entry)
                     <tr>
-                        <td data-order="{{ $character_id }}">
-                            {!! img('character', $character_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
-                            <a href="{{ route('character.view.sheet', ['character_id' => $character_id]) }}">
+                        <td data-order="{{ $entry->character_id }}">
+                            {!! img('character', $entry->character_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+                            <a href="{{ route('character.view.sheet', ['character_id' => $entry->character_id]) }}">
                               <span class="id-to-name"
-                                    data-id="{{ $character_id }}">{{ trans('web::seat.unknown') }}</span>
+                                    data-id="{{ $entry->character_id }}">{{ trans('web::seat.unknown') }}</span>
                             </a>
                         </td>
                         <td class="text-right" data-order="{{ $entry->quantity }}">{{ number($entry->quantity) }}</td>
                         <td class="text-right" data-order="{{ $entry->volumes }}">{{ number($entry->volumes) }} m3</td>
-                        <td class="text-right" data-order="{{ $entry->value }}">{{ number($entry->value) }} ISK</td>
+                        <td class="text-right" data-order="{{ $entry->amounts }}">{{ number($entry->amounts) }} ISK</td>
                     </tr>
                     @endforeach
                 </tbody>
             </table>
         </div>
-        <div class="panel-footer">Total : {{ number($entries->sum('value')) }} ISK</div>
+        <div class="panel-footer">Total : {{ number($entries->sum('amounts')) }} ISK</div>
     </div>
 @stop
 

--- a/src/resources/views/partials/miningvalue.blade.php
+++ b/src/resources/views/partials/miningvalue.blade.php
@@ -1,1 +1,1 @@
-{{number($row->value)}} ISK
+{{number($row->amounts)}} ISK


### PR DESCRIPTION
Since last update applied for price updating, every retrieved ledger entry is leading to a load
from historical_price table. On ledger display, it's causing big issues.

depends on eveseat/eveapi#123 and eveseat/services#65