### PR TITLE
fix(settings): Fix GA tracking explanation dead link

### DIFF
--- a/src/resources/views/configuration/settings/view.blade.php
+++ b/src/resources/views/configuration/settings/view.blade.php
@@ -104,7 +104,7 @@
               </select>
               <span class="help-block">
                 {{ trans('web::seat.tracking_help') }}
-                <a href="https://eveseat.github.io/docs/guides/admin/tracking/">Usage Tracking</a>
+                <a href="https://eveseat.github.io/docs/admin_guides/understanding_tracking/">Usage Tracking</a>
               </span>
             </div>
           </div>


### PR DESCRIPTION
Due to the documentation refactor, it appears we broke the documentation link referenced into
settings. This documentation page is explaining the GA Tracking purpose.

Closes eveseat/seat#443