### PR TITLE
use laravels `loadMigrationsFrom()` method instead of publishing ass…

### DIFF
--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -74,6 +74,9 @@ class WebServiceProvider extends ServiceProvider
         // Publish the JS & CSS, and Database migrations
         $this->add_publications();
 
+        // Inform Laravel how to load migrations
+        $this->add_migrations();
+
         // Add the views for the 'web' namespace
         $this->add_views();
 
@@ -118,12 +121,21 @@ class WebServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/resources/assets'                                        => public_path('web'),
-            __DIR__ . '/database/migrations/'                                    => database_path('migrations'),
 
             // Font Awesome Pulled from packagist
             base_path('vendor/components/font-awesome/css/font-awesome.min.css') => public_path('web/css/font-awesome.min.css'),
             base_path('vendor/components/font-awesome/fonts')                    => public_path('web/fonts'),
         ]);
+    }
+
+    /**
+     * Set the path for migrations which should
+     * be migrated by laravel. More informations:
+     * https://laravel.com/docs/5.5/packages#migrations
+     */
+    public function add_migrations()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations/');
     }
 
     /**

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -129,16 +129,6 @@ class WebServiceProvider extends ServiceProvider
     }
 
     /**
-     * Set the path for migrations which should
-     * be migrated by laravel. More informations:
-     * https://laravel.com/docs/5.5/packages#migrations.
-     */
-    public function add_migrations()
-    {
-        $this->loadMigrationsFrom(__DIR__ . '/database/migrations/');
-    }
-
-    /**
      * Set the path and namespace for the vies.
      */
     public function add_views()
@@ -392,6 +382,16 @@ class WebServiceProvider extends ServiceProvider
             );
         });
 
+    }
+
+    /**
+     * Set the path for migrations which should
+     * be migrated by laravel. More informations:
+     * https://laravel.com/docs/5.5/packages#migrations.
+     */
+    private function add_migrations()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations/');
     }
 
     /**


### PR DESCRIPTION
use laravels `loadMigrationsFrom()` method instead of publishing assets

This is based on a review feedback from @warlof:
https://github.com/eveseat/web/pull/233/files#r234420908 