### PR TITLE
fix(users): Reduce user coupling and avoid null exception

### DIFF
--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -79,6 +79,16 @@ class SsoController extends Controller
             return redirect()->route('auth.login')
                 ->with('error', 'Login failed. Please contact your administrator.');
 
+        // ensure the user got a valid group - spawn it otherwise
+        if (is_null($user->group)) {
+            Group::forceCreate([
+                'id' => $user->group_id,
+            ]);
+
+            // force laravel to update model relationship information
+            $user->load('group');
+        }
+
         // Set the main characterID based on the response.
         $this->updateMainCharacterId($user);
 
@@ -113,7 +123,7 @@ class SsoController extends Controller
                 // Update the group_id for this user based on the current
                 // session status. If there is a user already logged in,
                 // simply associate the user with a new group id. If not,
-                // a new grou is generated and given to this user.
+                // a new group is generated and given to this user.
                 $existing->group_id = auth()->check() ?
                     auth()->user()->group->id : Group::create()->id;
 

--- a/src/Http/Controllers/Configuration/UserController.php
+++ b/src/Http/Controllers/Configuration/UserController.php
@@ -74,6 +74,10 @@ class UserController extends Controller
                 return view('web::configuration.users.partials.action-buttons', compact('row'));
             })
             ->addColumn('roles', function (User $user) {
+
+                if (! $user->group)
+                    return trans('web::seat.no') . ' ' . trans_choice('web::seat.role', 2);
+
                 $roles = $user->group->roles->map(function ($role) {
                     return $role->title;
                 })->implode(', ');
@@ -82,11 +86,17 @@ class UserController extends Controller
             })
             ->addColumn('main_character', function (User $user) {
 
-                    return optional($user->group->main_character)->name ?: '';
-                })
-                ->addColumn('main_character_blade', function (User $user) {
+                if (! $user->group)
+                    return '';
 
-                $main_character_id = optional($user->group->main_character)->character_id ?: null;
+                return optional($user->group->main_character)->name ?: '';
+            })
+            ->addColumn('main_character_blade', function (User $user) {
+
+                $main_character_id = null;
+
+                if ($user->group)
+                    $main_character_id = optional($user->group->main_character)->character_id ?: null;
 
                 $character = CharacterInfo::find($main_character_id) ?: $main_character_id;
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -253,7 +253,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function getEmailAttribute()
     {
 
-        return Profile::get('email_address', $this->group->id);
+        return Profile::get('email_address', $this->group_id) ?: '';
     }
 
     /**

--- a/src/resources/views/configuration/users/edit.blade.php
+++ b/src/resources/views/configuration/users/edit.blade.php
@@ -64,12 +64,14 @@
           <dt>Current User Group</dt>
           <dd>
             <ul class="list-unstyled">
-              @foreach($user->group->users as $group_user)
-                <li>
-                  {!! img('character', $group_user->id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
-                  {{ $group_user->name }}
-                </li>
-              @endforeach
+              @if($user->group)
+                @foreach($user->group->users as $group_user)
+                  <li>
+                    {!! img('character', $group_user->id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+                    {{ $group_user->name }}
+                  </li>
+                @endforeach
+              @endif
             </ul>
           </dd>
         </dl>
@@ -131,44 +133,46 @@
               <th></th>
             </tr>
 
-            @foreach($user->group->roles as $role)
+            @if($user->group)
+              @foreach($user->group->roles as $role)
 
-              <tr>
-                <td>{{ $role->title }}</td>
-                <td>
-                  @foreach($role->permissions as $permission)
-                    <span
-                        class="label label-{{ $permission->title == 'superuser' ? 'danger' : 'info' }}">{{ studly_case($permission->title) }}</span>
-                  @endforeach
-                </td>
-                <td>
-                  @foreach($role->affiliations as $affiliation)
-                    <span class="label label-primary">{{ $affiliation->affiliation }} ({{ $affiliation->type }})</span>
-                  @endforeach
-                </td>
-                <td>
-                  @if(auth()->user()->id != $user->id)
-                    <a href="{{ route('configuration.access.roles.edit', ['id' => $role->id]) }}" type="button"
-                       class="btn btn-warning btn-xs">
-                      {{ trans('web::seat.edit') }}
-                    </a>
-                    <a href="{{ route('configuration.access.roles.edit.remove.group', ['role_id' => $role->id, 'user_id' => $user->group->id]) }}"
-                       type="button" class="btn btn-danger btn-xs">
-                      {{ trans('web::seat.remove') }}
-                    </a>
-                  @endif
-                </td>
+                <tr>
+                  <td>{{ $role->title }}</td>
+                  <td>
+                    @foreach($role->permissions as $permission)
+                      <span
+                          class="label label-{{ $permission->title == 'superuser' ? 'danger' : 'info' }}">{{ studly_case($permission->title) }}</span>
+                    @endforeach
+                  </td>
+                  <td>
+                    @foreach($role->affiliations as $affiliation)
+                      <span class="label label-primary">{{ $affiliation->affiliation }} ({{ $affiliation->type }})</span>
+                    @endforeach
+                  </td>
+                  <td>
+                    @if(auth()->user()->id != $user->id)
+                      <a href="{{ route('configuration.access.roles.edit', ['id' => $role->id]) }}" type="button"
+                         class="btn btn-warning btn-xs">
+                        {{ trans('web::seat.edit') }}
+                      </a>
+                      <a href="{{ route('configuration.access.roles.edit.remove.group', ['role_id' => $role->id, 'user_id' => $user->group->id]) }}"
+                         type="button" class="btn btn-danger btn-xs">
+                        {{ trans('web::seat.remove') }}
+                      </a>
+                    @endif
+                  </td>
 
-              </tr>
+                </tr>
 
-            @endforeach
+              @endforeach
+            @endif
 
             </tbody>
           </table>
 
         </div>
         <div class="panel-footer">
-          <b>{{ count($user->group->roles) }}</b> {{ trans_choice('web::seat.role', count($user->group->roles)) }}
+          <b>{{ count(optional($user->group)->roles) }}</b> {{ trans_choice('web::seat.role', count(optional($user->group)->roles)) }}
         </div>
       </div>
       @endif


### PR DESCRIPTION
When an user is attached to a non existing group, the user list may
crash due to some relation which are returning a null value.

This is reducing coupling for an User model by using directly the group_id from
the user entry and excluding things attached to group when none are
returned (mails, role, etc...).

Closes eveseat/seat#491