### PR TITLE
Name title view

### DIFF
--- a/src/Http/Composers/CharacterLayout.php
+++ b/src/Http/Composers/CharacterLayout.php
@@ -1,0 +1,56 @@
+<?php
+/*
+This file is part of SeAT
+
+Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+namespace Seat\Web\Http\Composers;
+
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Seat\Eveapi\Models\Character\CharacterInfo;
+
+class CharacterLayout
+{
+
+    protected $request;
+
+    /**
+     * CharacterLayout constructor.
+     * @param Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Bind Character Name to the view.
+     *
+     * @param View $view
+     */
+    public function compose(View $view)
+    {
+        $character_info = CharacterInfo::find($this->request->character_id);
+
+        if (! is_null($character_info))
+            $view->with('character_name', $character_info->name);
+    }
+
+}

--- a/src/Http/Composers/CorporationLayout.php
+++ b/src/Http/Composers/CorporationLayout.php
@@ -24,9 +24,9 @@ namespace Seat\Web\Http\Composers;
 
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
-use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
-class CharacterLayout
+class CorporationLayout
 {
 
     protected $request;
@@ -47,9 +47,9 @@ class CharacterLayout
      */
     public function compose(View $view)
     {
-        $character_info = CharacterInfo::find($this->request->character_id);
+        $corporation_info = CorporationInfo::find($this->request->corporation_id);
 
-        if (! is_null($character_info))
-            $view->with('character_name', $character_info->name);
+        if (! is_null($corporation_info))
+            $view->with('corporation_name', $corporation_info->name);
     }
 }

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -37,6 +37,7 @@ use Seat\Web\Events\Logout;
 use Seat\Web\Events\SecLog;
 use Seat\Web\Events\Security;
 use Seat\Web\Extentions\EveOnlineProvider;
+use Seat\Web\Http\Composers\CharacterLayout;
 use Seat\Web\Http\Composers\CharacterMenu;
 use Seat\Web\Http\Composers\CharacterSummary;
 use Seat\Web\Http\Composers\CorporationMenu;
@@ -172,6 +173,11 @@ class WebServiceProvider extends ServiceProvider
         $this->app['view']->composer([
             'web::character.includes.menu',
         ], CharacterMenu::class);
+
+        // Character layout breadcrumb
+        $this->app['view']->composer([
+            'web::character.layouts.view',
+        ], CharacterLayout::class);
 
         // Corporation info composer
         $this->app['view']->composer([

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -40,6 +40,7 @@ use Seat\Web\Extentions\EveOnlineProvider;
 use Seat\Web\Http\Composers\CharacterLayout;
 use Seat\Web\Http\Composers\CharacterMenu;
 use Seat\Web\Http\Composers\CharacterSummary;
+use Seat\Web\Http\Composers\CorporationLayout;
 use Seat\Web\Http\Composers\CorporationMenu;
 use Seat\Web\Http\Composers\CorporationSummary;
 use Seat\Web\Http\Composers\Esi;
@@ -192,6 +193,11 @@ class WebServiceProvider extends ServiceProvider
         $this->app['view']->composer([
             'web::corporation.includes.menu',
         ], CorporationMenu::class);
+
+        // Corporation layout breadcrumb
+        $this->app['view']->composer([
+            'web::corporation.layouts.view',
+        ], CorporationLayout::class);
 
     }
 

--- a/src/resources/views/character/assets.blade.php
+++ b/src/resources/views/character/assets.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'assets'])
+@extends('web::character.layouts.view', ['viewname' => 'assets', 'breadcrumb' => trans('web::seat.assets')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.assets'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.assets'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/bookmarks.blade.php
+++ b/src/resources/views/character/bookmarks.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'bookmarks'])
+@extends('web::character.layouts.view', ['viewname' => 'bookmarks', 'breadcrumb' => trans_choice('web::seat.bookmark', 2)])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans_choice('web::seat.bookmark', 2))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans_choice('web::seat.bookmark', 2))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/calendar.blade.php
+++ b/src/resources/views/character/calendar.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'calendar'])
+@extends('web::character.layouts.view', ['viewname' => 'calendar', 'breadcrumb' => trans('web::seat.calendar')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.calendar'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.calendar'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/contacts.blade.php
+++ b/src/resources/views/character/contacts.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'contacts'])
+@extends('web::character.layouts.view', ['viewname' => 'contacts', 'breadcrumb' => trans('web::seat.contacts')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.contacts'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.contacts'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/contracts.blade.php
+++ b/src/resources/views/character/contracts.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'contracts'])
+@extends('web::character.layouts.view', ['viewname' => 'contracts', 'breadcrumb' => trans('web::seat.contracts')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.contracts'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.contracts'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/fittings.blade.php
+++ b/src/resources/views/character/fittings.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'fittings'])
+@extends('web::character.layouts.view', ['viewname' => 'fittings', 'breadcrumb' => trans('web::seat.fittings')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.fittings'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.fittings'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/industry.blade.php
+++ b/src/resources/views/character/industry.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'industry'])
+@extends('web::character.layouts.view', ['viewname' => 'industry', 'breadcrumb' => trans('web::seat.industry')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.industry'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.industry'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/intel/journaldetail.blade.php
+++ b/src/resources/views/character/intel/journaldetail.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.intel.layouts.view', ['sub_viewname' => 'journal_detail'])
+@extends('web::character.intel.layouts.view', ['sub_viewname' => 'journal_detail', 'breadcrumb' => trans('web::seat.intel')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/intel/notes.blade.php
+++ b/src/resources/views/character/intel/notes.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.intel.layouts.view', ['sub_viewname' => 'note'])
+@extends('web::character.intel.layouts.view', ['sub_viewname' => 'note', 'breadcrumb' => trans('web::seat.intel')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/intel/standingscompare.blade.php
+++ b/src/resources/views/character/intel/standingscompare.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.intel.layouts.view', ['sub_viewname' => 'standings'])
+@extends('web::character.intel.layouts.view', ['sub_viewname' => 'standings', 'breadcrumb' => trans('web::seat.intel')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/intel/summary.blade.php
+++ b/src/resources/views/character/intel/summary.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.intel.layouts.view', ['sub_viewname' => 'summary'])
+@extends('web::character.intel.layouts.view', ['sub_viewname' => 'summary', 'breadcrumb' => trans('web::seat.intel')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.intel'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/killmails.blade.php
+++ b/src/resources/views/character/killmails.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'killmails'])
+@extends('web::character.layouts.view', ['viewname' => 'killmails', 'breadcrumb' => trans('web::seat.killmails')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.killmails'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.killmails'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/layouts/view.blade.php
+++ b/src/resources/views/character/layouts/view.blade.php
@@ -1,5 +1,7 @@
 @extends('web::layouts.grids.12')
 
+@section('title', trans_choice('web::seat.character', 1) . (isset($character_name) ? ' - ' . $character_name : '') . (isset($breadcrumb) ? ' > ' . $breadcrumb : ''))
+
 @section('full')
 
   <div class="row">

--- a/src/resources/views/character/mail.blade.php
+++ b/src/resources/views/character/mail.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'mail'])
+@extends('web::character.layouts.view', ['viewname' => 'mail', 'breadcrumb' => trans('web::seat.mail')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.mail'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.mail'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/market.blade.php
+++ b/src/resources/views/character/market.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'market'])
+@extends('web::character.layouts.view', ['viewname' => 'market', 'breadcrumb' => trans('web::seat.market')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.market'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.market'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/mining-ledger.blade.php
+++ b/src/resources/views/character/mining-ledger.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'mining-ledger'])
+@extends('web::character.layouts.view', ['viewname' => 'mining-ledger', 'breadcrumb' => trans('web::seat.mining')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.mining'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.mining'))
 
 @inject('request', Illuminate\Http\Request')

--- a/src/resources/views/character/notifications.blade.php
+++ b/src/resources/views/character/notifications.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'notifications'])
+@extends('web::character.layouts.view', ['viewname' => 'notifications', 'breadcrumb' => trans('web::seat.notifications')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.notifications'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.notifications'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/pi.blade.php
+++ b/src/resources/views/character/pi.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'pi'])
+@extends('web::character.layouts.view', ['viewname' => 'pi', 'breadcrumb' => trans('web::seat.pi')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.pi'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.pi'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/research.blade.php
+++ b/src/resources/views/character/research.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'research'])
+@extends('web::character.layouts.view', ['viewname' => 'research', 'breadcrumb' => trans('web::seat.research')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.research'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.research'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/sheet.blade.php
+++ b/src/resources/views/character/sheet.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'sheet'])
+@extends('web::character.layouts.view', ['viewname' => 'sheet', 'breadcrumb' => trans('web::seat.sheet')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.sheet'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.sheet'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/skills.blade.php
+++ b/src/resources/views/character/skills.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'skills'])
+@extends('web::character.layouts.view', ['viewname' => 'skills', 'breadcrumb' => trans('web::seat.skills')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.skills'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.skills'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/standings.blade.php
+++ b/src/resources/views/character/standings.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.layouts.view', ['viewname' => 'standings'])
+@extends('web::character.layouts.view', ['viewname' => 'standings', 'breadcrumb' => trans('web::seat.standings')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.standings'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.standings'))
 
 @section('character_content')

--- a/src/resources/views/character/wallet/journal/journal.blade.php
+++ b/src/resources/views/character/wallet/journal/journal.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.wallet.layouts.view', ['sub_viewname' => 'journal'])
+@extends('web::character.wallet.layouts.view', ['sub_viewname' => 'journal', 'breadcrumb' => trans('web::seat.wallet_journal')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.wallet_journal'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.wallet_journal'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/character/wallet/transactions/transactions.blade.php
+++ b/src/resources/views/character/wallet/transactions/transactions.blade.php
@@ -1,6 +1,5 @@
-@extends('web::character.wallet.layouts.view', ['sub_viewname' => 'transactions'])
+@extends('web::character.wallet.layouts.view', ['sub_viewname' => 'transactions', 'breadcrumb' => trans('web::seat.wallet_transactions')])
 
-@section('title', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.wallet_transactions'))
 @section('page_header', trans_choice('web::seat.character', 1) . ' ' . trans('web::seat.wallet_transactions'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/assets.blade.php
+++ b/src/resources/views/corporation/assets.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'assets'])
+@extends('web::corporation.layouts.view', ['viewname' => 'assets', 'breadcrumb' => trans('web::seat.assets')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.assets'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.assets'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/bookmarks.blade.php
+++ b/src/resources/views/corporation/bookmarks.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'bookmarks'])
+@extends('web::corporation.layouts.view', ['viewname' => 'bookmarks', 'breadcrumb' => trans_choice('web::seat.bookmark', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.bookmark', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.bookmark', 2))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/contacts.blade.php
+++ b/src/resources/views/corporation/contacts.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'contacts'])
+@extends('web::corporation.layouts.view', ['viewname' => 'contacts', 'breadcrumb' => trans('web::seat.contacts')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.contacts'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.contacts'))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/contracts.blade.php
+++ b/src/resources/views/corporation/contracts.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'contracts'])
+@extends('web::corporation.layouts.view', ['viewname' => 'contracts', 'breadcrumb' => trans('web::seat.contracts')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.contracts'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.contracts'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/industry.blade.php
+++ b/src/resources/views/corporation/industry.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'industry'])
+@extends('web::corporation.layouts.view', ['viewname' => 'industry', 'breadcrumb' => trans('web::seat.industry')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.industry'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.industry'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/killmails.blade.php
+++ b/src/resources/views/corporation/killmails.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'killmails'])
+@extends('web::corporation.layouts.view', ['viewname' => 'killmails', 'breadcrumb' => trans('web::seat.killmails')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.killmails'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.killmails'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/layouts/view.blade.php
+++ b/src/resources/views/corporation/layouts/view.blade.php
@@ -1,5 +1,7 @@
 @extends('web::layouts.grids.12')
 
+@section('title', trans_choice('web::seat.corporation', 1) . (isset($corporation_name) ? ' - ' . $corporation_name : '') . (isset($breadcrumb) ? ' > ' . $breadcrumb : ''))
+
 @section('full')
 
   <div class="row">

--- a/src/resources/views/corporation/ledger/bountyprizesbymonth.blade.php
+++ b/src/resources/views/corporation/ledger/bountyprizesbymonth.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'bountyprizesbymonth'])
+@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'bountyprizesbymonth', 'breadcrumb' => trans_choice('web::seat.bountyprizesbymonth', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.bountyprizesbymonth', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.bountyprizesbymonth', 2))
 
 @section('ledger_content')

--- a/src/resources/views/corporation/ledger/planetaryinteraction.blade.php
+++ b/src/resources/views/corporation/ledger/planetaryinteraction.blade.php
@@ -1,7 +1,6 @@
-@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'planetaryinteraction'])
+@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'planetaryinteraction', 'breadcrumb' => trans_choice('web::seat.pi', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.planetaryinteraction', 2))
-@section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.planetaryinteraction', 2))
+@section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.pi', 2))
 
 @section('ledger_content')
 

--- a/src/resources/views/corporation/ledger/walletsummary.blade.php
+++ b/src/resources/views/corporation/ledger/walletsummary.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'summary'])
+@extends('web::corporation.ledger.layouts.view', ['sub_viewname' => 'summary', 'breadcrumb' => trans_choice('web::seat.wallet_divisions', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.wallet_divisions', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.wallet_divisions', 2))
 
 @section('ledger_content')

--- a/src/resources/views/corporation/market.blade.php
+++ b/src/resources/views/corporation/market.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'market'])
+@extends('web::corporation.layouts.view', ['viewname' => 'market', 'breadcrumb' => trans('web::seat.market')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.market'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.market'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/mining/ledger.blade.php
+++ b/src/resources/views/corporation/mining/ledger.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.mining.layouts.view', ['sub_viewname' => 'ledger'])
+@extends('web::corporation.mining.layouts.view', ['sub_viewname' => 'ledger', 'breadcrumb' => trans('web::seat.mining')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' | ' . trans('web::seat.mining') . ' ' . trans_choice('web::seat.mining_ledger', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.mining') . ' ' . trans_choice('web::seat.mining_ledger', 2))
 
 @section('mining_content')

--- a/src/resources/views/corporation/pocos.blade.php
+++ b/src/resources/views/corporation/pocos.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'pocos'])
+@extends('web::corporation.layouts.view', ['viewname' => 'pocos', 'breadcrumb' => trans('web::seat.pocos')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.pocos'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.pocos'))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/security/log.blade.php
+++ b/src/resources/views/corporation/security/log.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'log'])
+@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'log', 'breadcrumb' => trans_choice('web::seat.log', 1)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.log', 1))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.log', 1))
 
 @section('security_content')

--- a/src/resources/views/corporation/security/roles.blade.php
+++ b/src/resources/views/corporation/security/roles.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'roles'])
+@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'roles', 'breadcrumb' => trans_choice('web::seat.role', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.roles', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.role', 2))
 
 @section('security_content')

--- a/src/resources/views/corporation/security/titles.blade.php
+++ b/src/resources/views/corporation/security/titles.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'titles'])
+@extends('web::corporation.security.layouts.view', ['sub_viewname' => 'titles', 'breadcrumb' => trans_choice('web::seat.title', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.title', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.title', 2))
 
 @section('security_content')

--- a/src/resources/views/corporation/standings.blade.php
+++ b/src/resources/views/corporation/standings.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'standings'])
+@extends('web::corporation.layouts.view', ['viewname' => 'standings', 'breadcrumb' => trans('web::seat.standings')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.standings'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.standings'))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/starbases.blade.php
+++ b/src/resources/views/corporation/starbases.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'starbases'])
+@extends('web::corporation.layouts.view', ['viewname' => 'starbases', 'breadcrumb' => trans_choice('web::seat.starbase', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.starbase', 2))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.starbase', 2))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/structures.blade.php
+++ b/src/resources/views/corporation/structures.blade.php
@@ -1,7 +1,6 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'structures'])
+@extends('web::corporation.layouts.view', ['viewname' => 'structures', 'breadcrumb' => trans_choice('web::seat.structure', 2)])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.starbase', 2))
-@section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.starbase', 2))
+@section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.structure', 2))
 
 @inject('request', 'Illuminate\Http\Request')
 

--- a/src/resources/views/corporation/summary.blade.php
+++ b/src/resources/views/corporation/summary.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'summary'])
+@extends('web::corporation.layouts.view', ['viewname' => 'summary', 'breadcrumb' => trans('web::seat.summary')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.summary'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.summary'))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/tracking.blade.php
+++ b/src/resources/views/corporation/tracking.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.layouts.view', ['viewname' => 'tracking'])
+@extends('web::corporation.layouts.view', ['viewname' => 'tracking', 'breadcrumb' => trans('web::seat.tracking')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.tracking'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.tracking'))
 
 @section('corporation_content')

--- a/src/resources/views/corporation/wallet/journal/journal.blade.php
+++ b/src/resources/views/corporation/wallet/journal/journal.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.wallet.layouts.view', ['sub_viewname' => 'journal'])
+@extends('web::corporation.wallet.layouts.view', ['sub_viewname' => 'journal', 'breadcrumb' => trans('web::seat.wallet_journal')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.wallet_journal'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.wallet_journal'))
 
 @inject('request', 'Illuminate\Http\Request')

--- a/src/resources/views/corporation/wallet/transactions/transactions.blade.php
+++ b/src/resources/views/corporation/wallet/transactions/transactions.blade.php
@@ -1,6 +1,5 @@
-@extends('web::corporation.wallet.layouts.view', ['sub_viewname' => 'transactions'])
+@extends('web::corporation.wallet.layouts.view', ['sub_viewname' => 'transactions', 'breadcrumb' => trans('web::seat.wallet_transactions')])
 
-@section('title', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.wallet_transactions'))
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans('web::seat.wallet_transactions'))
 
 @inject('request', 'Illuminate\Http\Request')


### PR DESCRIPTION
Upgrade both character and corporation layouts in order to introduce the entity name into the page `<title>` tag.

Introduce a new layout parameter called `breadcrumb` which will be used in order to pass the blade title to the page title. The entity name is sent via a View Composer.

Closes eveseat/seat#500
