### PR TITLE
fix(ACL): Avoid null exception on Horizon access check

### DIFF
--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -287,6 +287,9 @@ class WebServiceProvider extends AbstractSeatPlugin
         // Require the queue_manager role to view the dashboard
         Horizon::auth(function ($request) {
 
+            if (is_null($request->user()))
+                return false;
+
             return $request->user()->has('queue_manager', false);
         });
 


### PR DESCRIPTION
Due to the way Horizon access is checked, user method may be unset
which will result in a null exception during the access control to the
board.

```
Call to a member function has() on null in
/var/www/seat/packages/eveseat/web/src/WebServiceProvider.php on line
290
```