### PR TITLE
refactor(routes): review characters and corporations routes to better match REST

### DIFF
--- a/src/Http/Routes/Character/View.php
+++ b/src/Http/Routes/Character/View.php
@@ -20,337 +20,348 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-Route::get('/list', [
+Route::get('/', [
     'as'   => 'character.list',
     'uses' => 'CharacterController@getCharacters',
 ]);
 
-Route::get('/list/data', [
+Route::get('/data/', [
     'as'   => 'character.list.data',
     'uses' => 'CharacterController@getCharactersData',
 ]);
 
-Route::get('/delete/{character_id}', [
+Route::get('/{character_id}/delete/', [
     'as'         => 'character.delete',
     'middleware' => 'bouncer:superuser',
     'uses'       => 'CharacterController@deleteCharacter',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/assets/{character_id}', [
+Route::get('/{character_id}/assets/', [
     'as'         => 'character.view.assets',
     'middleware' => 'characterbouncer:assets',
     'uses'       => 'AssetsController@getAssetsView',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/assets/{character_id}/details', [
+Route::get('/{character_id}/assets/details/', [
     'as'         => 'character.view.assets.details',
     'middleware' => 'characterbouncer:assets',
     'uses'       => 'AssetsController@getCharacterAssets',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/bookmarks/{character_id}', [
+Route::get('/{character_id}/bookmarks/', [
     'as'         => 'character.view.bookmarks',
     'middleware' => 'characterbouncer:bookmarks',
     'uses'       => 'BookmarksController@getBookmarks',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/calendar/{character_id}', [
+Route::get('/{character_id}/calendar/', [
     'as'         => 'character.view.calendar',
     'middleware' => 'characterbouncer:calendar',
     'uses'       => 'CalendarController@getCalendar',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/contacts/{character_id}', [
+Route::get('/{character_id}/contacts/', [
     'as'         => 'character.view.contacts',
     'middleware' => 'characterbouncer:contacts',
     'uses'       => 'ContactsController@getContacts',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/contracts/{character_id}', [
+Route::get('/{character_id}/contracts/', [
     'as'         => 'character.view.contracts',
     'middleware' => 'characterbouncer:contracts',
     'uses'       => 'ContractsController@getContracts',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/contracts/data/{character_id}', [
+Route::get('/{character_id}/contracts/data/', [
     'as'         => 'character.view.contracts.data',
     'middleware' => 'characterbouncer:contracts',
     'uses'       => 'ContractsController@getContractsData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/contracts/items/{character_id}/{contract_id}', [
+Route::get('{character_id}/contracts/{contract_id}/items/', [
     'as'         => 'character.view.contracts.items',
     'middleware' => 'characterbouncer:contracts',
     'uses'       => 'ContractsController@getContractsItemsData',
-]);
+])->where('character_id', '[0-9]+')
+  ->where('contract_id', '[0-9]+');
 
-Route::get('/view/fittings/{character_id}', [
+Route::get('/{character_id}/fittings/', [
     'as'         => 'character.view.fittings',
     'middleware' => 'characterbouncer:fittings',
     'uses'       => 'FittingController@getFittings',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/fittings/items/{character_id}/{fitting_id}', [
+Route::get('/{character_id}/fittings/{fitting_id}/items/', [
     'as'         => 'character.view.fittings.items',
     'middleware' => 'characterbouncer:fittings',
     'uses'       => 'FittingController@getFittingItems',
-]);
+])->where('character_id', '[0-9]+')
+  ->where('fitting_id', '[0-9]+');
 
-Route::get('/view/industry/{character_id}', [
+Route::get('/{character_id}/industry/', [
     'as'         => 'character.view.industry',
     'middleware' => 'characterbouncer:industry',
     'uses'       => 'IndustryController@getIndustry',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/industry/data/{character_id}', [
+Route::get('/{character_id}/industry/data/', [
     'as'         => 'character.view.industry.data',
     'middleware' => 'characterbouncer:industry',
     'uses'       => 'IndustryController@getIndustryData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::group(['prefix' => 'view/intel'], function () {
+Route::group(['prefix' => 'intel'], function () {
 
-    Route::get('summary/{character_id}', [
+    Route::get('/{character_id}/summary/', [
         'as'         => 'character.view.intel.summary',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getIntelSummary',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
     // Ajax Call Journal
-    Route::get('summary/journal/data/{character_id}', [
+    Route::get('{character_id}/summary/journal/data/', [
         'as'         => 'character.view.intel.summary.journal.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getTopWalletJournalData',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('summary/journal/details/{first_party_id}/{second_party_id}', [
+    Route::get('{first_party_id}/{second_party_id}/summary/journal/details/', [
         'as'         => 'character.view.intel.summary.journal.details',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getJournalContent',
-    ]);
+    ])->where('first_party_id', '[0-9]+')
+      ->where('second_party_id', '[0-9]+');
 
     // Transactions
-    Route::get('summary/transactions/data/{character_id}', [
+    Route::get('{character_id}/summary/transactions/data/', [
         'as'         => 'character.view.intel.summary.transactions.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getTopTransactionsData',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('summary/transactions/details/{character_id}/{client_id}', [
+    Route::get('{character_id}/summary/transactions/{client_id}/details/', [
         'as'         => 'character.view.intel.summary.transactions.details',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getTransactionContent',
-    ]);
+    ])->where('character_id', '[0-9]+')
+      ->where('client_id', '[0-9]+');
 
     // Mail
-    Route::get('summary/mail/data/{character_id}', [
+    Route::get('{character_id}/summary/mail/data/', [
         'as'         => 'character.view.intel.summary.mail.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getTopMailFromData',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('summary/mail/details/{character_id}/{from}', [
+    Route::get('{character_id}/summary/mail/{from}/details/', [
         'as'         => 'character.view.intel.summary.mail.details',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getTopMailContent',
-    ]);
+    ])->where('character_id', '[0-9]+')
+      ->where('from', '[0-9]+');
 
     // Standings Comparison
-    Route::get('comparison/{character_id}', [
+    Route::get('{character_id}/comparison/', [
         'as'         => 'character.view.intel.standingscomparison',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getStandingsComparison',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('comparison/data/{character_id}/{profile_id}', [
+    Route::get('{character_id}/comparison/{profile_id}/data/', [
         'as'         => 'character.view.intel.standingscomparison.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getCompareStandingsWithProfileData',
-    ]);
+    ])->where('character_id', '[0-9]+')
+      ->where('profile_id', '[0-9]+');
 
     // Notes
-    Route::get('notes/{character_id}', [
+    Route::get('{character_id}/notes/', [
         'as'         => 'character.view.intel.notes',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getNotes',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('notes/data/{character_id}', [
+    Route::get('{character_id}/notes/data/', [
         'as'         => 'character.view.intel.notes.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getNotesData',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('notes/single/data/{character_id}/{note_id}', [
+    Route::get('{character_id}/notes/{note_id}/single/data/', [
         'as'         => 'character.view.intel.notes.single.data',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getSingleNotesData',
-    ]);
+    ])->where('character_id', '[0-9]+')
+      ->where('note_id', '[0-9]+');
 
-    Route::post('notes/new/{character_id}', [
+    Route::post('{character_id}/notes/new/', [
         'as'         => 'character.view.intel.notes.new',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@postAddNew',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::post('notes/update/{character_id}', [
+    Route::post('{character_id}/notes/update/', [
         'as'         => 'character.view.intel.notes.update',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@postUpdateNote',
-    ]);
+    ])->where('character_id', '[0-9]+');
 
-    Route::get('notes/delete/{character_id}/{note_id}', [
+    Route::get('{character_id}/notes/{note_id}/delete/', [
         'as'         => 'character.view.intel.notes.delete',
         'middleware' => 'characterbouncer:intel',
         'uses'       => 'IntelController@getDeleteNote',
-    ]);
+    ])->where('character_id', '[0-9]+')
+      ->where('note_id', '[0-9]+');
 
 });
 
-Route::get('/view/journal/{character_id}', [
+Route::get('/{character_id}/journal/', [
     'as'         => 'character.view.journal',
     'middleware' => 'characterbouncer:journal',
     'uses'       => 'WalletController@getJournal',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/journal/data/{character_id}', [
+Route::get('/{character_id}/journal/data/', [
     'as'         => 'character.view.journal.data',
     'middleware' => 'characterbouncer:journal',
     'uses'       => 'WalletController@getJournalData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/journal/graph/balance/{character_id}', [
+Route::get('/{character_id}/journal/graph/balance/', [
     'as'         => 'character.view.journal.graph.balance',
     'middleware' => 'characterbouncer:journal',
     'uses'       => 'WalletController@getJournalGraphBalance',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/killmails/{character_id}', [
+Route::get('/{character_id}/killmails/', [
     'as'         => 'character.view.killmails',
     'middleware' => 'characterbouncer:killmails',
     'uses'       => 'KillmailController@getKillmails',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/killmails/data/{character_id}', [
+Route::get('/{character_id}/killmails/data/', [
     'as'         => 'character.view.killmails.data',
     'middleware' => 'characterbouncer:killmails',
     'uses'       => 'KillmailController@getKillmailsData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/mail/timeline', [
+Route::get('/mail/timeline/', [
     'as'   => 'character.view.mail.timeline',
     'uses' => 'MailController@getMailTimeline',
 ]);
 
-Route::get('/view/mail/timeline/read/{message_id}', [
+Route::get('/mail/timeline/{message_id}/read/', [
     'as'   => 'character.view.mail.timeline.read',
     'uses' => 'MailController@getMailTimelineRead',
-]);
+])->where('message_id', '[0-9]+');
 
-Route::get('/view/mail/{character_id}', [
+Route::get('/{character_id}/mail/', [
     'as'         => 'character.view.mail',
     'middleware' => 'characterbouncer:mail',
     'uses'       => 'MailController@getMail',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/mail/data/{character_id}', [
+Route::get('/{character_id}/mail/data/', [
     'as'         => 'character.view.mail.data',
     'middleware' => 'characterbouncer:mail',
     'uses'       => 'MailController@getMailData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/mail/{character_id}/read/{message_id}', [
+Route::get('/{character_id}/mail/{message_id}/read/', [
     'as'         => 'character.view.mail.read',
     'middleware' => 'characterbouncer:mail',
     'uses'       => 'MailController@getMailRead',
-]);
+])->where('character_id', '[0-9]+')
+  ->where('message_id', '[0-9]+');
 
-Route::get('/view/market/{character_id}', [
+Route::get('/{character_id}/market/', [
     'as'         => 'character.view.market',
     'middleware' => 'characterbouncer:market',
     'uses'       => 'MarketController@getMarket',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/market/data/{character_id}', [
+Route::get('/{character_id}/market/data/', [
     'as'         => 'character.view.market.data',
     'middleware' => 'characterbouncer:market',
     'uses'       => 'MarketController@getMarketData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/mining-ledger/{character_id}', [
+Route::get('/{character_id}/mining-ledger/', [
     'as'         => 'character.view.mining_ledger',
     'middleware' => 'characterbouncer:mining',
     'uses'       => 'MiningLedgerController@getLedger',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/mining-ledger/{character_id}/data', [
+Route::get('/{character_id}/mining-ledger/data/', [
     'as'         => 'character.view.mining_ledger.data',
     'middleware' => 'characterbouncer:mining',
     'uses'       => 'MiningLedgerController@getMiningLedger',
 ]);
 
-Route::get('/view/mining-ledger/{character_id}/{date}/{system_id}/{type_id}', [
+Route::get('/{character_id}/mining-ledger/{date}/{system_id}/{type_id}/', [
     'as'         => 'character.view.detailed_mining_ledger',
     'middleware' => 'characterbouncer:mining',
     'uses'       => 'MiningLedgerController@getDetailedLedger',
-]);
+])->where('character_id', '[0-9]+')
+  ->where('system_id', '[0-9]+')
+  ->where('type_id', '[0-9]+');
 
-Route::get('/view/notifications/{character_id}', [
+Route::get('/{character_id}/notifications/', [
     'as'         => 'character.view.notifications',
     'middleware' => 'characterbouncer:notifications',
     'uses'       => 'NotificationsController@getNotifications',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/pi/{character_id}', [
+Route::get('/{character_id}/pi/', [
     'as'         => 'character.view.pi',
     'middleware' => 'characterbouncer:pi',
     'uses'       => 'PiController@getPi',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/research/{character_id}', [
+Route::get('/{character_id}/research/', [
     'as'         => 'character.view.research',
     'middleware' => 'characterbouncer:research',
     'uses'       => 'ResearchController@getResearch',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/sheet/{character_id}', [
+Route::get('/{character_id}/sheet/', [
     'as'         => 'character.view.sheet',
     'middleware' => 'characterbouncer:sheet',
     'uses'       => 'SheetController@getSheet',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/skills/{character_id}', [
+Route::get('/{character_id}/skills/', [
     'as'         => 'character.view.skills',
     'middleware' => 'characterbouncer:skills',
     'uses'       => 'SkillsController@getSkills',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/skills/graph/level/{character_id}', [
+Route::get('/{character_id}/skills/graph/level/', [
     'as'         => 'character.view.skills.graph.level',
     'middleware' => 'characterbouncer:sheet',
     'uses'       => 'SkillsController@getCharacterSkillsLevelChartData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/skills/graph/coverage/{character_id}', [
+Route::get('/{character_id}/skills/graph/coverage/', [
     'as'         => 'character.view.skills.graph.coverage',
     'middleware' => 'characterbouncer:sheet',
     'uses'       => 'SkillsController@getCharacterSkillsCoverageChartData',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/standings/{character_id}', [
+Route::get('/{character_id}/standings/', [
     'as'         => 'character.view.standings',
     'middleware' => 'characterbouncer:standings',
     'uses'       => 'StandingsController@getStandings',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/transactions/{character_id}', [
+Route::get('/{character_id}/transactions/', [
     'as'         => 'character.view.transactions',
     'middleware' => 'characterbouncer:transactions',
     'uses'       => 'WalletController@getTransactions',
-]);
+])->where('character_id', '[0-9]+');
 
-Route::get('/view/transactions/data/{character_id}', [
+Route::get('/{character_id}/transactions/data/', [
     'as'         => 'character.view.transactions.data',
     'middleware' => 'characterbouncer:transactions',
     'uses'       => 'WalletController@getTransactionsData',
-]);
+])->where('character_id', '[0-9]+');

--- a/src/Http/Routes/Corporation/View.php
+++ b/src/Http/Routes/Corporation/View.php
@@ -20,230 +20,238 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-Route::get('/list', [
+Route::get('/', [
     'as'   => 'corporation.list',
     'uses' => 'CorporationsController@getCorporations',
 ]);
 
-Route::get('/list/data', [
+Route::get('/data/', [
     'as'   => 'corporation.list.data',
     'uses' => 'CorporationsController@getCorporationsData',
 ]);
 
-Route::get('/delete/{corporation_id}', [
+Route::get('/{corporation_id}/delete/', [
     'as'         => 'corporation.delete',
     'middleware' => 'bouncer:superuser',
     'uses'       => 'CorporationsController@deleteCorporation',
 ]);
 
-Route::get('/view/assets/{corporation_id}', [
+Route::get('/{corporation_id}/assets/', [
     'as'         => 'corporation.view.assets',
     'middleware' => 'corporationbouncer:assets',
     'uses'       => 'AssetsController@getAssets',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/assets/contents/{corporation_id}/{item_id}', [
+Route::get('/{corporation_id}/assets/{item_id}/contents/', [
     'as'         => 'corporation.view.assets.contents',
     'middleware' => 'corporationbouncer:assets',
     'uses'       => 'AssetsController@getAssetsContents',
-]);
+])->where('corporation_id', '[0-9]+')
+  ->where('item_id', '[0-9]+');
 
-Route::get('/view/bookmarks/{corporation_id}', [
+Route::get('/{corporation_id}/bookmarks/', [
     'as'         => 'corporation.view.bookmarks',
     'middleware' => 'corporationbouncer:bookmarks',
     'uses'       => 'BookmarksController@getBookmarks',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/contacts/{corporation_id}', [
+Route::get('/{corporation_id}/contacts/', [
     'as'         => 'corporation.view.contacts',
     'middleware' => 'corporationbouncer:contacts',
     'uses'       => 'ContactsController@getContacts',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/contracts/{corporation_id}', [
+Route::get('/{corporation_id}/contracts/', [
     'as'         => 'corporation.view.contracts',
     'middleware' => 'corporationbouncer:contracts',
     'uses'       => 'ContractsController@getContracts',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/contracts/data/{corporation_id}', [
+Route::get('/{corporation_id}/contracts/data/', [
     'as'         => 'corporation.view.contracts.data',
     'middleware' => 'corporationbouncer:contracts',
     'uses'       => 'ContractsController@getContractsData',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/contracts/items/{corporation_id}/{contract_id}', [
+Route::get('/{corporation_id}/contracts/{contract_id}/items/', [
     'as'         => 'corporation.view.contracts.items',
     'middleware' => 'corporationbouncer:contracts',
     'uses'       => 'ContractsController@getContractsItemsData',
-]);
+])->where('corporation_id', '[0-9]+')
+  ->where('contract_id', '[0-9]+');
 
-Route::get('/view/industry/{corporation_id}', [
+Route::get('/{corporation_id}/industry/', [
     'as'         => 'corporation.view.industry',
     'middleware' => 'corporationbouncer:industry',
     'uses'       => 'IndustryController@getIndustry',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/industry/data/{corporation_id}', [
+Route::get('/{corporation_id}/industry/data/', [
     'as'         => 'corporation.view.industry.data',
     'middleware' => 'corporationbouncer:industry',
     'uses'       => 'IndustryController@getIndustryData',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/killmails/{corporation_id}', [
+Route::get('/{corporation_id}/killmails/', [
     'as'         => 'corporation.view.killmails',
     'middleware' => 'corporationbouncer:killmails',
     'uses'       => 'KillmailsController@getKillmails',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/killmails/data/{corporation_id}', [
+Route::get('/{corporation_id}/killmails/data/', [
     'as'         => 'corporation.view.killmails.data',
     'middleware' => 'corporationbouncer:killmails',
     'uses'       => 'KillmailsController@getKillmailsData',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/market/{corporation_id}', [
+Route::get('/{corporation_id}/market/', [
     'as'         => 'corporation.view.market',
     'middleware' => 'corporationbouncer:market',
     'uses'       => 'MarketController@getMarket',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/market/data/{corporation_id}', [
+Route::get('/{corporation_id}/market/data/', [
     'as'         => 'corporation.view.market.data',
     'middleware' => 'corporationbouncer:market',
     'uses'       => 'MarketController@getMarketData',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/mining-ledger/{corporation_id}/{year?}/{month?}', [
+Route::get('/{corporation_id}/mining-ledger/{year?}/{month?}/', [
     'as'         => 'corporation.view.mining_ledger',
     'middleware' => 'corporationbouncer:mining',
     'uses'       => 'MiningLedgerController@getLedger',
-]);
+])->where('corporation_id', '[0-9]+')
+  ->where('year', '[0-9]{4}')
+  ->where('month', '[0-9]{2}');
 
-Route::get('/view/pocos/{corporation_id}', [
+Route::get('/{corporation_id}/pocos/', [
     'as'         => 'corporation.view.pocos',
     'middleware' => 'corporationbouncer:pocos',
     'uses'       => 'IndustryController@getPoco',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/extractions/{corporation_id}', [
+Route::get('/{corporation_id}/extractions/', [
     'as'         => 'corporation.view.extractions',
     'middleware' => 'corporationbouncer:extractions',
     'uses'       => 'ExtractionController@getExtractions',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::post('/view/extractions/report', [
+Route::post('/extractions/report/', [
     'as'         => 'corporation.view.extractions.probe-report',
     'middleware' => 'corporationbouncer:extractions',
     'uses'       => 'ExtractionController@postProbeReport',
 ]);
 
-Route::group(['prefix' => 'view/security'], function () {
+Route::group(['prefix' => '{corporation_id}/security'], function () {
 
-    Route::get('roles/{corporation_id}', [
+    Route::get('roles/', [
         'as'         => 'corporation.view.security.roles',
         'middleware' => 'corporationbouncer:security',
         'uses'       => 'SecurityController@getRoles',
-    ]);
+    ])->where('corporation_id', '[0-9]+');
 
-    Route::get('titles/{corporation_id}', [
+    Route::get('titles/', [
         'as'         => 'corporation.view.security.titles',
         'middleware' => 'corporationbouncer:security',
         'uses'       => 'SecurityController@getTitles',
-    ]);
+    ])->where('corporation_id', '[0-9]+');
 
-    Route::get('log/{corporation_id}', [
+    Route::get('log/', [
         'as'         => 'corporation.view.security.log',
         'middleware' => 'corporationbouncer:security',
         'uses'       => 'SecurityController@getLog',
-    ]);
+    ])->where('corporation_id', '[0-9]+');
 
 });
 
-Route::group(['prefix' => 'view/ledger'], function () {
+Route::group(['prefix' => '{corporation_id}/ledger'], function () {
 
-    Route::get('summary/{corporation_id}', [
+    Route::get('summary/', [
         'as'         => 'corporation.view.ledger.summary',
         'middleware' => 'corporationbouncer:ledger',
         'uses'       => 'LedgerController@getWalletSummary',
-    ]);
+    ])->where('corporation_id', '[0-9]+');
 
-    Route::get('bountyprizes/{corporation_id}/{year?}/{month?}', [
+    Route::get('bountyprizes/{year?}/{month?}/', [
         'as'         => 'corporation.view.ledger.bountyprizesbymonth',
         'middleware' => 'corporationbouncer:ledger',
         'uses'       => 'LedgerController@getBountyPrizesByMonth',
-    ]);
+    ])->where('corporation_id', '[0-9]+')
+      ->where('year', '[0-9]{4}')
+      ->where('month', '[0-9]{1,2}');
 
-    Route::get('planetaryinteraction/{corporation_id}/{year?}/{month?}', [
+    Route::get('planetaryinteraction/{year?}/{month?}/', [
         'as'         => 'corporation.view.ledger.planetaryinteraction',
         'middleware' => 'corporationbouncer:ledger',
         'uses'       => 'LedgerController@getPlanetaryInteractionByMonth',
-    ]);
+    ])->where('corporation_id', '[0-9]+')
+      ->where('year', '[0-9]{4}')
+      ->where('month', '[0-9]{1,2}');
 
 });
 
-Route::get('/view/summary/{corporation_id}', [
+Route::get('/{corporation_id}/summary/', [
     'as'         => 'corporation.view.summary',
     'middleware' => 'corporationbouncer:summary',
     'uses'       => 'SummaryController@getSummary',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/standings/{corporation_id}', [
+Route::get('/{corporation_id}/standings/', [
     'as'         => 'corporation.view.standings',
     'middleware' => 'corporationbouncer:standings',
     'uses'       => 'StandingsController@getStandings',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/starbases/{corporation_id}', [
+Route::get('/{corporation_id}/starbases/', [
     'as'         => 'corporation.view.starbases',
     'middleware' => 'corporationbouncer:starbases',
     'uses'       => 'StarbaseController@getStarbases',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::post('/view/starbase/modules/{corporation_id}', [
+Route::post('/{corporation_id}/starbase/modules/', [
     'as'         => 'corporation.view.starbase.modules',
     'middleware' => 'corporationbouncer:starbases',
     'uses'       => 'StarbaseController@postStarbaseModules',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/structures/{corporation_id}', [
+Route::get('/{corporation_id}/structures/', [
     'as'         => 'corporation.view.structures',
     'middleware' => 'corporationbouncer:structures',
     'uses'       => 'StructureController@getStructures',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/tracking/{corporation_id}', [
+Route::get('/{corporation_id}/tracking/', [
     'as'         => 'corporation.view.tracking',
     'middleware' => 'corporationbouncer:tracking',
     'uses'       => 'TrackingController@getTracking',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/tracking/{corporation_id}/membertracking', [
+Route::get('/{corporation_id}/tracking/membertracking/', [
     'as'         => 'corporation.view.tracking.data',
     'middleware' => 'corporationbouncer:tracking',
     'uses'       => 'TrackingController@getMemberTracking',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/journal/{corporation_id}', [
+Route::get('/{corporation_id}/journal/', [
     'as'         => 'corporation.view.journal',
     'middleware' => 'corporationbouncer:journal',
     'uses'       => 'WalletController@getJournal',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/journal/data/{corporation_id}', [
+Route::get('/{corporation_id}/journal/data/', [
     'as'         => 'corporation.view.journal.data',
     'middleware' => 'corporationbouncer:journal',
     'uses'       => 'WalletController@getJournalData',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/transactions/{corporation_id}', [
+Route::get('/{corporation_id}/transactions/', [
     'as'         => 'corporation.view.transactions',
     'middleware' => 'corporationbouncer:transactions',
     'uses'       => 'WalletController@getTransactions',
-]);
+])->where('corporation_id', '[0-9]+');
 
-Route::get('/view/transactions/data/{corporation_id}', [
+Route::get('/{corporation_id}/transactions/data/', [
     'as'         => 'corporation.view.transactions.data',
     'middleware' => 'corporationbouncer:transactions',
     'uses'       => 'WalletController@getTransactionsData',
-]);
+])->where('corporation_id', '[0-9]+');

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -102,7 +102,7 @@ Route::group([
         // Corporation Routes
         Route::group([
             'namespace' => 'Corporation',
-            'prefix'    => 'corporation',
+            'prefix'    => 'corporations',
         ], function () {
 
             include __DIR__ . '/Routes/Corporation/View.php';
@@ -111,7 +111,7 @@ Route::group([
         // Character Routes
         Route::group([
             'namespace' => 'Character',
-            'prefix'    => 'character',
+            'prefix'    => 'characters',
         ], function () {
 
             include __DIR__ . '/Routes/Character/View.php';


### PR DESCRIPTION
use plural for scope endpoint :
 - character become characters
 - corporation become corporations

remove `view` keyword as it's not useful and put entity_id at front of path
 - /character/view/*/{character_id} become /characters/{character_id}/*
 - /corporation/view/*/{corporation_id} become /corporations/{corporation_id}/*