### PR TITLE
Use a default redirect in order to avoid sheet access to be mandatory

### DIFF
--- a/src/Http/Controllers/Corporation/CorporationsController.php
+++ b/src/Http/Controllers/Corporation/CorporationsController.php
@@ -36,6 +36,45 @@ class CorporationsController extends Controller
     use Corporation;
 
     /**
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function getCorporation()
+    {
+        // by default, redirect user to corporation sheet
+        if (auth()->user()->has('corporation.summary'))
+            return redirect()->route('corporation.view.summary', [
+                'corporation_id' => request()->corporation_id,
+            ]);
+
+        // collect all registered routes for corporation scope and sort them alphabetically
+        $configured_routes = array_values(array_sort(config('package.corporation.menu'), function ($menu) {
+            return $menu['name'];
+        }));
+
+        // for each route, check if the current user got a valid access and redirect him to the first valid entry
+        foreach ($configured_routes as $menu) {
+            $permissions = $menu['permission'];
+
+            if (! is_array($permissions))
+                $permissions = [$permissions];
+
+            foreach ($permissions as $permission) {
+                if (auth()->user()->has($permission))
+                    return redirect()->route($menu['route'], [
+                        'corporation_id' => request()->corporation_id,
+                    ]);
+            }
+        }
+
+        $message = sprintf('Request to %s was denied by the corporationbouncer.', request()->path());
+
+        event('security.log', [$message, 'authorization']);
+
+        // Redirect away from the original request
+        return redirect()->route('auth.unauthorized');
+    }
+
+    /**
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function getCorporations()

--- a/src/Http/Routes/Character/View.php
+++ b/src/Http/Routes/Character/View.php
@@ -30,6 +30,11 @@ Route::get('/list/data', [
     'uses' => 'CharacterController@getCharactersData',
 ]);
 
+Route::get('/{character_id}', [
+    'as'   => 'character.view.default',
+    'uses' => 'CharacterController@getCharacter',
+])->where('character_id', '[0-9]+');
+
 Route::get('/delete/{character_id}', [
     'as'         => 'character.delete',
     'middleware' => 'bouncer:superuser',

--- a/src/Http/Routes/Corporation/View.php
+++ b/src/Http/Routes/Corporation/View.php
@@ -33,7 +33,7 @@ Route::get('/list/data', [
 Route::get('/{corporation_id}', [
     'as'         => 'corporation.view.default',
     'uses'       => 'CorporationsController@getCorporation',
-]);
+])->where('corporation_id', '[0-9]+');
 
 Route::get('/delete/{corporation_id}', [
     'as'         => 'corporation.delete',

--- a/src/Http/Routes/Corporation/View.php
+++ b/src/Http/Routes/Corporation/View.php
@@ -30,6 +30,11 @@ Route::get('/list/data', [
     'uses' => 'CorporationsController@getCorporationsData',
 ]);
 
+Route::get('/{corporation_id}', [
+    'as'         => 'corporation.view.default',
+    'uses'       => 'CorporationsController@getCorporation',
+]);
+
 Route::get('/delete/{corporation_id}', [
     'as'         => 'corporation.delete',
     'middleware' => 'bouncer:superuser',

--- a/src/resources/views/partials/character.blade.php
+++ b/src/resources/views/partials/character.blade.php
@@ -4,7 +4,7 @@
 
 @if (isset($character->name))
 
-  <a href="{{ route('character.view.sheet', ['character_id' => $character->character_id]) }}">
+  <a href="{{ route('character.view.default', ['character_id' => $character->character_id]) }}">
     {!! img('character', $character->character_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
     {{$character->name}}
   </a>

--- a/src/resources/views/partials/corporation.blade.php
+++ b/src/resources/views/partials/corporation.blade.php
@@ -4,7 +4,7 @@
 
 @if (isset($corporation->name) )
 
-  <a href="{{ route('corporation.view.summary', ['corporation_id' => $corporation->corporation_id]) }}">
+  <a href="{{ route('corporation.view.default', ['corporation_id' => $corporation->corporation_id]) }}">
     {!! img('corporation', $corporation->corporation_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
     {{$corporation->name}}
   </a>


### PR DESCRIPTION
In order to avoid an user to have either `corporation.summary` or
`character.sheet` access, this is adding a default route for both scope
in charge of checking the first valid access which will then be used to
redirect the user.