### PR TITLE
fix(user): ensure the email address is properly updated

### DIFF
--- a/src/Http/Validation/EditUser.php
+++ b/src/Http/Validation/EditUser.php
@@ -49,13 +49,8 @@ class EditUser extends FormRequest
     public function rules()
     {
 
-        // Get the id of the user that will be used to ignore
-        // the email constraint on.
-        $user_id = $this->request->get('user_id');
-
         return [
             'user_id' => 'required|exists:users,id',
-            'email'   => 'required|email|unique:users,email,' . $user_id,
         ];
     }
 }

--- a/src/lang/en/seat.php
+++ b/src/lang/en/seat.php
@@ -628,6 +628,7 @@ return [
     'current_email'                => 'Current Email',
     'new_email'                    => 'New Email',
     'confirm_new_email'            => 'Confirm New Email',
+    'email_in_use'                 => 'The e-mail address :mail is already in use.',
     'scan_qr'                      => 'Scan QR Code',
     'scan_qr_help1'                => 'Please scan the below QR code with your authenticator application.',
     'scan_qr_help2'                => 'Each time this page loads, a new token and qr code is generated.',


### PR DESCRIPTION
Since 3.x, the e-mail address field has been removed from user table and
become an user setting. However, it seems it has not been properly
updated during the migration.

Closes eveseat/seat#493