### PR TITLE
refactor(squads): improve list layout with dynamic search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "yajra/laravel-datatables-oracle": "~9",
     "yajra/laravel-datatables-buttons": "^4.0",
     "intervention/image": "^2.5",
+    "lasserafn/php-initial-avatar-generator": "^4.0",
     "components/font-awesome": "^5.9",
     "erusev/parsedown": "^1.7",
     "almasaeed2010/adminlte": "^3.0",

--- a/src/Http/Scopes/SquadScope.php
+++ b/src/Http/Scopes/SquadScope.php
@@ -20,24 +20,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Web\Http\DataTables\Scopes;
+namespace Seat\Web\Http\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;
-use Yajra\DataTables\Contracts\DataTableScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
 
 /**
  * Class SquadScope.
  *
- * @package Seat\Web\Http\DataTables\Scopes
+ * @package Seat\Web\Http\Scopes
  */
-class SquadScope implements DataTableScope
+class SquadScope implements Scope
 {
     /**
      * {@inheritdoc}
      */
-    public function apply($query)
+    public function apply(Builder $builder, Model $model)
     {
-        return $query->whereIn('type', ['manual', 'auto'])
+        if (auth()->user()->hasSuperUser())
+            return $builder;
+
+        return $builder->whereIn('type', ['manual', 'auto'])
             ->orWhereHas('moderators', function (Builder $sub_query) {
                 $sub_query->where('id', auth()->user()->id);
             })

--- a/src/Models/Squads/Squad.php
+++ b/src/Models/Squads/Squad.php
@@ -179,6 +179,58 @@ class Squad extends Model
     }
 
     /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeCandidate($query)
+    {
+        return $query->whereHas('applications', function ($sub_query) {
+            $sub_query->where('user_id', auth()->user()->id);
+        });
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeMember($query)
+    {
+        return $query->whereHas('members', function ($sub_query) {
+            $sub_query->where('user_id', auth()->user()->id);
+        });
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeModerator($query)
+    {
+        return $query->whereHas('moderators', function ($sub_query) {
+            $sub_query->where('user_id', auth()->user()->id);
+        });
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeModerated($query)
+    {
+        return $query->where('is_moderated', true);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array $types
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOfType($query, $types)
+    {
+        return $query->whereIn('type', $types);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function applications()

--- a/src/resources/views/squads/list.blade.php
+++ b/src/resources/views/squads/list.blade.php
@@ -11,6 +11,12 @@
       </div>
       <div class="col">
         <div class="btn-group d-flex">
+          @if(auth()->user()->hasSuperUser())
+            <a href="{{ route('squads.create') }}" class="btn btn-default">
+              <i class="fas fa-plus"></i>
+              Create
+            </a>
+          @endif
           <button data-filter-field="type" data-filter-value="manual" type="button" class="btn btn-success deck-filters active">
             <i class="fas fa-check-circle"></i>
             Manual
@@ -97,9 +103,11 @@
                                                     <a href="${data.link}" class="btn btn-sm btn-light">
                                                         <i class="fas fa-eye"></i> Show
                                                     </a>
-                                                    <button class="btn btn-sm btn-danger" data-id="${data.id}">
+                                                    @if(auth()->user()->hasSuperUser())
+                                                    <button class="btn btn-sm btn-danger delete-squad" data-id="${data.id}">
                                                       <i class="fas fa-trash-alt"></i> Delete
                                                     </button>
+                                                    @endif
                                                 </div>
                                             </div>
                                         </div>
@@ -201,12 +209,24 @@
 
               refreshSquadDeck(keyword, $(this).data('page'));
           })
-          .on('click', '.deck-filters', function (e) {
+          .on('click', '.deck-filters', function () {
               var keyword = $('input[name="search-squad"]').val();
               $(this).hasClass('active') ? $(this).removeClass('active') : $(this).addClass('active');
               $(this).hasClass('active') ? $(this).prepend('<i class="fas fa-check-circle">') : $(this).find('i').remove();
 
               refreshSquadDeck(keyword, 1);
+          })
+          .on('click', '.delete-squad', function () {
+              var endpoint = `${window.location.protocol}//${window.location.hostname}:${window.location.port}${window.location.pathname}/${this.dataset.id}`;
+
+              $(this).closest('.card').fadeOut('slow');
+
+              $.ajax(endpoint, {
+                  method: 'DELETE'
+              }).always(function () {
+                  var keyword = $('input[name="search-squad"]').val();
+                  refreshSquadDeck(keyword, 1);
+              });
           });
   </script>
 @endpush

--- a/src/resources/views/squads/list.blade.php
+++ b/src/resources/views/squads/list.blade.php
@@ -11,14 +11,30 @@
       </div>
       <div class="col">
         <div class="btn-group d-flex">
-          <button data-filter-field="type" data-filter-value="manual" type="button" class="btn btn-success deck-filters active">Manual</button>
-          <button data-filter-field="type" data-filter-value="auto" type="button" class="btn btn-info deck-filters active">Auto</button>
-          <button data-filter-field="type" data-filter-value="hidden" type="button" class="btn btn-dark deck-filters active">Hidden</button>
-          <button data-filter-field="eligible" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-secondary deck-filters active">Eligible</button>
-          <button data-filter-field="candidates" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-primary deck-filters active">Candidates</button>
-          <button data-filter-field="members" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-light deck-filters active">Members</button>
-          <button data-filter-field="moderators" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-warning deck-filters active">Moderators</button>
-          <button data-filter-field="is_moderated" data-filter-value="true" type="button" class="btn btn-danger deck-filters active">Moderated</button>
+          <button data-filter-field="type" data-filter-value="manual" type="button" class="btn btn-success deck-filters active">
+            <i class="fas fa-check-circle"></i>
+            Manual
+          </button>
+          <button data-filter-field="type" data-filter-value="auto" type="button" class="btn btn-info deck-filters active">
+            <i class="fas fa-check-circle"></i>
+            Auto
+          </button>
+          <button data-filter-field="type" data-filter-value="hidden" type="button" class="btn btn-dark deck-filters active">
+            <i class="fas fa-check-circle"></i>
+            Hidden
+          </button>
+          <button data-filter-field="candidates" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-primary deck-filters">
+            Candidate
+          </button>
+          <button data-filter-field="members" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-light deck-filters">
+            Member
+          </button>
+          <button data-filter-field="moderators" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-warning deck-filters">
+            Moderator
+          </button>
+          <button data-filter-field="is_moderated" data-filter-value="true" type="button" class="btn btn-danger deck-filters">
+            Moderated Only
+          </button>
         </div>
       </div>
     </div>
@@ -119,9 +135,19 @@
       }
 
       function refreshSquadDeck(keyword, page) {
+          var filters = {};
           var endpoint = `${window.location.protocol}//${window.location.hostname}:${window.location.port}${window.location.pathname}`;
 
-          $.get(endpoint, {query: keyword, page: page}, function (d) {
+          $('.deck-filters.active').each(function (i, e) {
+              var a = $(e);
+              var f = a.data('filter-field');
+              var v = a.data('filter-value');
+
+              if (! filters[f]) filters[f] = [];
+              filters[f].push(v);
+          });
+
+          $.get(endpoint, {query: keyword, page: page, filters: filters}, function (d) {
               $('#squad-deck').empty();
 
               chunk(d.data, 6).forEach(function (row) {
@@ -164,17 +190,23 @@
           refreshSquadDeck(this.value, 1);
       }, 500));
 
-      $(document).on('click', '.pagination a', function(e) {
-          var keyword = $('input[name="search-squad]').val();
-          e.preventDefault();
+      $(document)
+          .on('click', '.pagination a', function(e) {
+              var keyword = $('input[name="search-squad]').val();
+              e.preventDefault();
 
-          $('.pagination li')
-              .removeClass('active');
+              $('.pagination li').removeClass('active');
 
-          $(this).parent('li')
-              .addClass('active');
+              $(this).parent('li').addClass('active');
 
-          refreshSquadDeck(keyword, $(this).data('page'));
-      });
+              refreshSquadDeck(keyword, $(this).data('page'));
+          })
+          .on('click', '.deck-filters', function (e) {
+              var keyword = $('input[name="search-squad"]').val();
+              $(this).hasClass('active') ? $(this).removeClass('active') : $(this).addClass('active');
+              $(this).hasClass('active') ? $(this).prepend('<i class="fas fa-check-circle">') : $(this).find('i').remove();
+
+              refreshSquadDeck(keyword, 1);
+          });
   </script>
 @endpush

--- a/src/resources/views/squads/list.blade.php
+++ b/src/resources/views/squads/list.blade.php
@@ -4,25 +4,177 @@
 @section('page_header', trans_choice('web::squads.squad', 0))
 
 @section('full')
-  <div class="card card-default">
-    <div class="card-header">
-      <h3 class="card-title">List</h3>
-      <div class="card-tools">
-        <div class="input-group input-group-sm">
-          @if(auth()->user()->hasSuperUser())
-            <a class="btn btn-sm btn-light" href="{{ route('squads.create') }}">
-              <i class="fas fa-plus"></i>
-            </a>
-          @endif
+  <form onsubmit="return false;">
+    <div class="form-row align-items-center mb-3">
+      <div class="col">
+        <input name="search-squad" type="text" class="form-control" placeholder="Search" />
+      </div>
+      <div class="col">
+        <div class="btn-group d-flex">
+          <button data-filter-field="type" data-filter-value="manual" type="button" class="btn btn-success deck-filters active">Manual</button>
+          <button data-filter-field="type" data-filter-value="auto" type="button" class="btn btn-info deck-filters active">Auto</button>
+          <button data-filter-field="type" data-filter-value="hidden" type="button" class="btn btn-dark deck-filters active">Hidden</button>
+          <button data-filter-field="eligible" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-secondary deck-filters active">Eligible</button>
+          <button data-filter-field="candidates" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-primary deck-filters active">Candidates</button>
+          <button data-filter-field="members" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-light deck-filters active">Members</button>
+          <button data-filter-field="moderators" data-filter-value="{{ auth()->user()->id }}" type="button" class="btn btn-warning deck-filters active">Moderators</button>
+          <button data-filter-field="is_moderated" data-filter-value="true" type="button" class="btn btn-danger deck-filters active">Moderated</button>
         </div>
       </div>
     </div>
-    <div class="card-body">
-      {!! $dataTable->table() !!}
-    </div>
-  </div>
+  </form>
+
+  <div id="squad-deck"></div>
+
+  <nav>
+    <ul class="pagination justify-content-center" id="pagination-squad"></ul>
+  </nav>
+
 @endsection
 
 @push('javascript')
-  {!! $dataTable->scripts() !!}
+  <script>
+      const chunk = (arr, size) =>
+          Array.from({ length: Math.ceil(arr.length / size) }, (v, i) =>
+              arr.slice(i * size, i * size + size)
+          );
+
+      const card_factory = (data) => `<div class="col mb-4">
+                                        <div class="card h-100">
+                                            <img src="${data.logo}" alt="${data.name}" width="128" class="card-img-top" />
+                                            <div class="card-body pb-0">
+                                                <h5 class="card-title">${data.name}</h5>
+                                                <p class="card-text">${data.summary}</p>
+                                                <ul class="list-group list-group-flush">
+                                                    <li class="list-group-item">
+                                                        ${data.is_moderated ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}
+                                                        moderated
+                                                    </li>
+                                                    <li class="list-group-item">
+                                                        ${data.is_moderator ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}
+                                                        moderator
+                                                    </li>
+                                                    <li class="list-group-item">
+                                                        ${data.is_member ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}
+                                                        member
+                                                    </li>
+                                                    <li class="list-group-item">
+                                                        ${data.is_candidate ? '<i class="fas fa-check text-success"></i>' : '<i class="fas fa-times text-danger"></i>'}
+                                                        candidate
+                                                    </li>
+                                                </ul>
+                                                <div class="row mt-3">
+                                                    <div class="col-4 text-center">
+                                                        <span class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="top" title="Candidates">${data.applications_count}</span>
+                                                    </div>
+                                                    <div class="col-4 text-center">
+                                                        <span class="badge badge-pill badge-light" data-toggle="tooltip" data-placement="top" title="Members">${data.members_count}</span>
+                                                    </div>
+                                                    <div class="col-4 text-center">
+                                                        <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="top" title="Moderators">${data.moderators_count}</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="card-footer">
+                                                <span class="badge ${data.type === 'hidden' ? 'badge-dark' : data.type === 'auto' ? 'badge-info' : 'badge-success' }">${data.type.substr(0, 1).toUpperCase() + data.type.substr(1).toLowerCase()}</span>
+                                                <div class="btn-group float-right">
+                                                    <a href="${data.link}" class="btn btn-sm btn-light">
+                                                        <i class="fas fa-eye"></i> Show
+                                                    </a>
+                                                    <button class="btn btn-sm btn-danger" data-id="${data.id}">
+                                                      <i class="fas fa-trash-alt"></i> Delete
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>`;
+
+      const pagination_first_page_factory = (data) => `<li class="page-item ${data.current_page === 1 ? 'disabled' : ''}" ${data.current_page === 1 ? 'aria-disabled="true"' : ''} aria-label="Previous">
+                                                        ${data.current_page === 1 ?
+                                                          '<span class="page-link" aria-hidden="true">&laquo;</span>' :
+                                                          '<a data-page="1" class="page-link" href="' + data.first_page_url + '" rel="previous" aria-label="Previous">&laquo;</a>'
+                                                         }
+                                                       </li>`;
+
+      const pagination_last_page_factory = (data) => `<li class="page-item ${data.current_page === data.last_page ? 'disabled' : ''}" ${data.current_page === data.last_page ? 'aria-disabled="true"' : ''} aria-label="Next">
+                                                        ${data.current_page === data.last_page ?
+                                                            '<span class="page-link" aria-hidden="true">&raquo;</span>' :
+                                                            '<a data-page="' + data.last_page + '" class="page-link" href="' + data.last_page_url + '" rel="next" aria-label="Next">&raquo;</a>'
+                                                        }
+                                                       </li>`;
+
+      const pagination_page_factory = (data, page) => `<li class="page-item ${data.current_page === page ? 'active': ''}" ${data.current_page === page ? 'aria-current="page"' : ''}>
+                                                        ${data.current_page === page ?
+                                                            '<span class="page-link">' + page + '</span>' :
+                                                            '<a data-page="' + page +'" class="page-link" href="' + data.path + '?page=' + page + '">' + page + '</a>'
+                                                        }
+                                                       </li>`;
+
+      function searchHandlerDelay(callback, ms) {
+          let timer = 0;
+          return function (...args) {
+              clearTimeout(timer);
+              timer = setTimeout(callback.bind(this, ...args), ms || 0);
+          };
+      }
+
+      function refreshSquadDeck(keyword, page) {
+          var endpoint = `${window.location.protocol}//${window.location.hostname}:${window.location.port}${window.location.pathname}`;
+
+          $.get(endpoint, {query: keyword, page: page}, function (d) {
+              $('#squad-deck').empty();
+
+              chunk(d.data, 6).forEach(function (row) {
+                  var squad_row = $('<div class="row row-cols-1 row-cols-md-6">');
+
+                  row.forEach(function (squad) {
+                      squad_row.append($(card_factory(squad)).hide().fadeIn('slow'));
+                  });
+
+                  if (row.length < 6) {
+                      for (var i = 0; i < (6 - row.length); i++)
+                          squad_row.append($('<div class="col mb-4">'));
+                  }
+
+                  $('#squad-deck').append(squad_row);
+              });
+
+              pagination = $('#pagination-squad');
+              pagination.empty();
+
+              pagination.append(pagination_first_page_factory(d));
+
+              for (var page = 1; page <= d.last_page; page++)
+                  pagination.append(pagination_page_factory(d, page));
+
+              pagination.append(pagination_last_page_factory(d));
+          });
+      }
+
+      $(document).ready(function () {
+          var keyword = $('input[name="search-squad"]').val();
+          refreshSquadDeck(keyword, 1);
+      });
+
+      $('body').tooltip({
+          selector: '[data-toggle="tooltip"]'
+      });
+
+      $('input[name="search-squad"]').on('keyup', searchHandlerDelay(function () {
+          refreshSquadDeck(this.value, 1);
+      }, 500));
+
+      $(document).on('click', '.pagination a', function(e) {
+          var keyword = $('input[name="search-squad]').val();
+          e.preventDefault();
+
+          $('.pagination li')
+              .removeClass('active');
+
+          $(this).parent('li')
+              .addClass('active');
+
+          refreshSquadDeck(keyword, $(this).data('page'));
+      });
+  </script>
 @endpush

--- a/src/resources/views/squads/show.blade.php
+++ b/src/resources/views/squads/show.blade.php
@@ -96,7 +96,7 @@
                   <h3 class="card-title">Members</h3>
                 </div>
                 <div class="card-body">
-                  @if($squad->isMember() || auth()->user()->hasSuperUser())
+                  @if($squad->is_member || auth()->user()->hasSuperUser())
                     {!! $dataTable->table() !!}
                   @else
                     <p class="text-center">You are not member of that squad.</p>
@@ -106,7 +106,7 @@
             </div>
           </div>
 
-          @if($squad->isModerator() || auth()->user()->hasSuperUser())
+          @if($squad->is_moderator || auth()->user()->hasSuperUser())
             <div class="row">
               <div class="col-12">
                 <div class="card ml-0 mr-0">


### PR DESCRIPTION
This commit is providing a different layout for squads listing due to recent complaint on Slack.

Previous table has been replaced by a paginated card deck, able to render up to 6 card a time.
For convenient ergonomy, most of controls are javascript based.

 - cards got a smooth fade effect while they're appearing
 - squad without a proper logo set got a named avatar style generated
 - pagination is updated dynamically according to user search

![image](https://user-images.githubusercontent.com/648753/71544769-734b7100-2983-11ea-9a48-f362077f4a2b.png)

![image](https://user-images.githubusercontent.com/648753/71544773-88280480-2983-11ea-9a70-a430af650775.png)

TODO :
 - [x] implementing filters button
 - [x] implementing delete event
 - [x] implementing add event
