### PR TITLE
fix(cve): this address an issue on affiliations permissions merge

### DIFF
--- a/src/Acl/AccessChecker.php
+++ b/src/Acl/AccessChecker.php
@@ -325,7 +325,7 @@ trait AccessChecker
                         foreach ($this->getAllCharacters()->pluck('character_id') as $characterID) {
 
                             if (isset($map['char'][$characterID]))
-                                $map['char'][$characterID] += $role_permissions;
+                                $map['char'][$characterID] = array_unique(array_merge($map['char'][$characterID], $role_permissions));
 
                             else
                                 $map['char'][$characterID] = $role_permissions;
@@ -339,7 +339,7 @@ trait AccessChecker
                         foreach ($this->getAllCorporations()->pluck('corporation_id') as $corporationID) {
 
                             if (isset($map['corp'][$corporationID]))
-                                $map['corp'][$corporationID] += $role_permissions;
+                                $map['corp'][$corporationID] = array_unique(array_merge($map['corp'][$corporationID], $role_permissions));
 
                             else
                                 $map['corp'][$corporationID] = $role_permissions;
@@ -377,7 +377,7 @@ trait AccessChecker
                     // affiliations already exist. Not using a ternary of coalesce operator
                     // here as it makes reading this really hard.
                     if (isset($map[$affiliation->type][$affiliation->affiliation]))
-                        $map[$affiliation->type][$affiliation->affiliation] += $role_permissions;
+                        $map[$affiliation->type][$affiliation->affiliation] = array_unique(array_merge($map[$affiliation->type][$affiliation->affiliation], $role_permissions));
 
                     else
                         $map[$affiliation->type][$affiliation->affiliation] = $role_permissions;


### PR DESCRIPTION
this is considered as a non critical bug.
however, due to the issue, it may cause strange behaviour while working with multiple roles getting similar affiliations.

previous way to merge permissions array was only appending permissions with a key which didn't exist in previous array related to the affiliation. As a result, some assigned permissions by a role, targeting an affiliation which was already set by a previous roles may be missing on role members.