### PR TITLE
(fix) update Login event to accomodate changes in Console package.

### DIFF
--- a/src/Events/Login.php
+++ b/src/Events/Login.php
@@ -65,11 +65,11 @@ class Login
         foreach ($event->user->refresh_tokens as $token) {
 
             // Update Character Information
-            (new CharacterTokenShouldUpdate($token, 'high'))->fire();
+            (new CharacterTokenShouldUpdate($token))->fire();
 
             // Update Corporation Information if user is Director (otherwise, keep normal flow)
             if (CharacterRole::where('character_id', $token->character_id)->where('role', 'Director')->exists())
-                (new CorporationTokenShouldUpdate($token, 'high'))->fire();
+                (new CorporationTokenShouldUpdate($token->affiliation->corporation_id, $token))->fire();
         }
     }
 }


### PR DESCRIPTION
An HTTP 500 error is generated during SSO login if the SeAT user has a refresh token/character with Director roles. The attempt to trigger CorporationTokenShouldUpdate in the Login event needed to be updated to accommodate the changes in commit 80b76dc.

From Laravel log: 
local.ERROR: Argument 1 passed to Seat\Console\Bus\CorporationTokenShouldUpdate::__construct() must be of the type int, object given, called in /var/www/seat/packages/eveseat/web/src/Events/Login.php on line 72 {"userId":47,"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to Seat\\Console\\Bus\\CorporationTokenShouldUpdate::__construct() must be of the type int, object given, called in /var/www/seat/packages/eveseat/web/src/Events/Login.php on line 72 at /var/www/seat/packages/eveseat/console/src/Bus/CorporationTokenShouldUpdate.php:89)