### PR TITLE
(fix) undefined property $entry->name in drop_groups_table migration

### DIFF
--- a/src/database/migrations/2019_11_12_220840_drop_groups_table.php
+++ b/src/database/migrations/2019_11_12_220840_drop_groups_table.php
@@ -67,7 +67,7 @@ class DropGroupsTable extends Migration
                 $join->on('users.group_id', 'user_settings.group_id');
                 $join->where('user_settings.name', 'main_character_id');
             })
-            ->select('users.group_id', 'users.id', 'users.character_owner_hash', 'user_settings.value')
+            ->select('users.group_id', 'users.id', 'users.name', 'users.character_owner_hash', 'user_settings.value')
             ->get();
 
         foreach ($entries as $entry) {


### PR DESCRIPTION
When a condition that triggers the Exception to be thrown is met, you instead get a different Exception when running the migration as the property $entry->name is undefined. Updated DB query to return the users name column.