### PR TITLE
fix(notifications): fix datatables error on character notifications from issue passing notification text from array to string

### DIFF
--- a/src/resources/views/character/notification.blade.php
+++ b/src/resources/views/character/notification.blade.php
@@ -1,3 +1,3 @@
-<i class="fa fa-comment" data-widget="popover" data-placement="top" title="" data-html="true"
-   data-trigger="hover" data-content="{{ clean_ccp_html($row->text) }}"></i>
+<i class="fa fa-comment" data-toggle="tooltip" data-placement="top" data-html="true"
+   title="{{ clean_ccp_html($row->getOriginal('text')) }}"></i>
 {{ preg_replace('/([a-z0-9])([A-Z])/', '$1 $2', $row->type) }}


### PR DESCRIPTION
The Accessor on the Character Notifications model parses the Yaml stored in the DB, but returns an array. Trying to access this results in a PHP error parsing the array to string. Also updated the Bootstrap 3 popover component to the new Bootstrap 4 tooltip component. 