### PR TITLE
Prepare api package for SeAT 4.0.x

### DIFF
--- a/src/Http/DataTables/Scopes/KillMailCharacterScope.php
+++ b/src/Http/DataTables/Scopes/KillMailCharacterScope.php
@@ -86,10 +86,12 @@ class KillMailCharacterScope implements DataTableScope
             }
         }
 
-        return $query->whereHas('attackers', function ($sub_query) use ($character_ids) {
-            $sub_query->whereIn('killmail_attackers.character_id', $character_ids);
-        })->orWhereHas('victim', function ($sub_query) use ($character_ids) {
-            $sub_query->whereIn('killmail_victims.character_id', $character_ids);
+        return $query->where(function ($sub_query) use ($character_ids) {
+            $sub_query->whereHas('attackers', function ($query) use ($character_ids) {
+                $query->whereIn('killmail_attackers.character_id', $character_ids);
+            })->orWhereHas('victim', function ($query) use ($character_ids) {
+                $query->whereIn('killmail_victims.character_id', $character_ids);
+            });
         });
     }
 }

--- a/src/Http/DataTables/Scopes/KillMailCorporationScope.php
+++ b/src/Http/DataTables/Scopes/KillMailCorporationScope.php
@@ -56,10 +56,12 @@ class KillMailCorporationScope implements DataTableScope
      */
     public function apply($query)
     {
-        return $query->whereHas('attackers', function ($sub_query) {
-            $sub_query->whereIn('killmail_attackers.corporation_id', $this->corporation_ids);
-        })->orWhereHas('victim', function ($sub_query) {
-            $sub_query->whereIn('killmail_victims.corporation_id', $this->corporation_ids);
+        return $query->where(function ($sub_query) {
+            $sub_query->whereHas('attackers', function ($query) {
+                $query->whereIn('killmail_attackers.corporation_id', $this->corporation_ids);
+            })->orWhereHas('victim', function ($query) {
+                $query->whereIn('killmail_victims.corporation_id', $this->corporation_ids);
+            });
         });
     }
 }

--- a/src/Http/DataTables/Scopes/MiningCorporationScope.php
+++ b/src/Http/DataTables/Scopes/MiningCorporationScope.php
@@ -67,11 +67,12 @@ class MiningCorporationScope implements DataTableScope
      */
     public function apply($query)
     {
-        return $query
-            ->where('year', $this->year)
-            ->where('month', $this->month)
-            ->whereHas('character.affiliation', function ($sub_query) {
-                $sub_query->whereIn('corporation_id', $this->corporation_ids);
-            });
+        return $query->where(function ($sub_query) {
+            $sub_query->where('year', $this->year)
+                ->where('month', $this->month)
+                ->whereHas('character.affiliation', function ($query) {
+                    $query->whereIn('corporation_id', $this->corporation_ids);
+                });
+        });
     }
 }

--- a/src/Models/Acl/Role.php
+++ b/src/Models/Acl/Role.php
@@ -31,6 +31,16 @@ use Seat\Web\Models\User;
 /**
  * Class Role.
  * @package Seat\Web\Models\Acl
+ *
+ * @OA\Schema(
+ *     type="object",
+ *     title="Role",
+ *     description="Role",
+ *     @OA\Property(property="id", type="integer", description="Role unique identifier"),
+ *     @OA\Property(property="title", type="string", description="Role name"),
+ *     @OA\Property(property="description", type="string", description="Role description"),
+ *     @OA\Property(property="logo", type="string", format="byte", description="Role logo"),
+ * )
  */
 class Role extends Model
 {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -40,85 +40,85 @@ use Seat\Web\Models\Squads\Squad;
  * Class User.
  * @package Seat\Web\Models
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="User",
  *     title="User",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="id",
  *     type="integer",
  *     format="int64",
  *     minimum=90000000,
- *     description="ID",
- *     property="id"
+ *     description="ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="name",
  *     type="string",
  *     description="Name",
- *     maxLength=255,
- *     property="name"
+ *     maxLength=255
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="email",
  *     type="string",
  *     format="email",
- *     description="E-Mail address",
- *     property="email"
+ *     description="E-Mail address"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="active",
  *     type="boolean",
- *     description="Account status",
- *     property="active"
+ *     description="Account status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="character_owner_hash",
  *     type="string",
  *     description="Unique character/EVE Account hash",
- *     maxLength=255,
- *     property="character_owner_hash"
+ *     maxLength=255
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="last_login",
  *     type="string",
  *     format="date-time",
- *     description="Last login to SeAT time",
- *     property="last_login"
+ *     description="Last login to SeAT time"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="last_login_source",
  *     type="string",
- *     description="Last IP address used to sign in to SeAT",
- *     property="last_login_source"
+ *     description="Last IP address used to sign in to SeAT"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="group_id",
  *     type="integer",
  *     minimum=1,
- *     description="Group ID",
- *     property="group_id"
+ *     description="Group ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="associated_character_ids",
  *     type="array",
  *     description="Array of attached character ID",
- *     property="associated_character_ids",
- *     @SWG\Items(type="integer", format="int64", minimum=90000000)
+ *     @OA\Items(type="integer", format="int64", minimum=90000000)
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="main_character_id",
  *     type="integer",
  *     format="int64",
  *     minimum=90000000,
- *     description="The main character ID of this group",
- *     property="main_character_id"
+ *     description="The main character ID of this group"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     property="token",
- *     ref="#/definitions/RefreshToken"
+ *     ref="#/components/schemas/RefreshToken"
  * )
  */
 class User extends Model implements AuthenticatableContract, CanResetPasswordContract


### PR DESCRIPTION
Upgrade API documentation annotation from Swagger (v2.0) to Open API (v3.0)
Main change is related to namespace which has been renamed from `SWG` to `OA`
There is also a replacement for the body parameter which got its own keyword `RequestBody`

Depends: eveseat/api#39 eveseat/eveapi#203