### PR TITLE
Avoid to spam ESI on each auth

### DIFF
--- a/src/Events/Login.php
+++ b/src/Events/Login.php
@@ -25,9 +25,6 @@ namespace Seat\Web\Events;
 use DateTime;
 use Illuminate\Auth\Events\Login as LoginEvent;
 use Illuminate\Support\Facades\Request;
-use Seat\Console\Bus\CharacterTokenShouldUpdate;
-use Seat\Console\Bus\CorporationTokenShouldUpdate;
-use Seat\Eveapi\Models\Character\CharacterRole;
 use Seat\Web\Models\UserLoginHistory;
 
 /**
@@ -61,15 +58,5 @@ class Login
 
         $message = 'User logged in from ' . Request::getClientIp();
         event('security.log', [$message, 'authentication']);
-
-        foreach ($event->user->refresh_tokens as $token) {
-
-            // Update Character Information
-            (new CharacterTokenShouldUpdate($token))->fire();
-
-            // Update Corporation Information if user is Director (otherwise, keep normal flow)
-            if (CharacterRole::where('character_id', $token->character_id)->where('role', 'Director')->exists())
-                (new CorporationTokenShouldUpdate($token->affiliation->corporation_id, $token))->fire();
-        }
     }
 }

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -142,14 +142,14 @@ class SsoController extends Controller
         ]);
 
         // Generate a new bucket User and use the authenticating character as main.
-        $user = new User();
-        $user->main_character_id = $eve_user->id;
-        $user->name = $eve_user->name;
-        $user->active = true;
-        $user->save();
+        $user = User::firstOrCreate([
+            'main_character_id' => $eve_user->id,
+        ], [
+            'name' => $eve_user->name,
+            'active' => true,
+        ]);
 
-        return User::where('main_character_id', $eve_user->id)
-            ->first();
+        return $user;
     }
 
     /**

--- a/src/Observers/CharacterRoleObserver.php
+++ b/src/Observers/CharacterRoleObserver.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Observers;
+
+use Exception;
+use Seat\Console\Bus\CorporationTokenShouldUpdate;
+use Seat\Eveapi\Models\Character\CharacterRole;
+use Seat\Eveapi\Models\RefreshToken;
+
+/**
+ * Class CharacterRoleObserver.
+ *
+ * @package Seat\Web\Observers
+ */
+class CharacterRoleObserver
+{
+    /**
+     * @param \Seat\Eveapi\Models\Character\CharacterRole $role
+     */
+    public function created(CharacterRole $role)
+    {
+        // in case the created role is not a Director role, ignore
+        if ($role->role != 'Director')
+            return;
+
+        // retrieve character related token
+        $token = RefreshToken::find($role->character_id);
+
+        if (is_null($token))
+            return;
+
+        try {
+            // enqueue jobs related to the character corporation
+            $job = new CorporationTokenShouldUpdate($token->affiliation->corporation_id, $token);
+            $job->fire();
+        } catch (Exception $e) {
+            logger()->error($e->getMessage());
+        }
+    }
+}

--- a/src/Observers/RefreshTokenObserver.php
+++ b/src/Observers/RefreshTokenObserver.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Observers;
+
+use Exception;
+use Seat\Console\Bus\CharacterTokenShouldUpdate;
+use Seat\Eveapi\Models\RefreshToken;
+
+/**
+ * Class RefreshTokenObserver.
+ *
+ * @package Seat\Web\Observers
+ */
+class RefreshTokenObserver
+{
+    /**
+     * @param \Seat\Eveapi\Models\RefreshToken $token
+     */
+    public function created(RefreshToken $token)
+    {
+        try {
+            $job = new CharacterTokenShouldUpdate($token);
+            $job->fire();
+        } catch (Exception $e) {
+            logger()->error($e->getMessage());
+        }
+    }
+}

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -32,7 +32,9 @@ use Illuminate\Support\Facades\Validator;
 use Laravel\Horizon\Horizon;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
+use Seat\Eveapi\Models\Character\CharacterRole;
 use Seat\Eveapi\Models\Character\CharacterSkill;
+use Seat\Eveapi\Models\RefreshToken;
 use Seat\Web\Events\Attempt;
 use Seat\Web\Events\Login;
 use Seat\Web\Events\Logout;
@@ -61,7 +63,9 @@ use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\Squads\SquadRole;
 use Seat\Web\Observers\CharacterAffiliationObserver;
 use Seat\Web\Observers\CharacterAssetObserver;
+use Seat\Web\Observers\CharacterRoleObserver;
 use Seat\Web\Observers\CharacterSkillObserver;
+use Seat\Web\Observers\RefreshTokenObserver;
 use Seat\Web\Observers\SquadMemberObserver;
 use Seat\Web\Observers\SquadRoleObserver;
 
@@ -282,6 +286,10 @@ class WebServiceProvider extends AbstractSeatPlugin
 
         // Custom Events
         $this->app->events->listen('security.log', SecLog::class);
+
+        // Characters / Corporations first auth - Jobs Events
+        CharacterRole::observe(CharacterRoleObserver::class);
+        RefreshToken::observe(RefreshTokenObserver::class);
 
         // Squads Events
         CharacterAffiliation::observe(CharacterAffiliationObserver::class);


### PR DESCRIPTION
to avoid ESI spam, we will enqueue all character jobs only on first authentication (when token is created). Otherwise, data will be updated using scheduler flow.

for the same reason, we will enqueue all corporation jobs only on character role of type Director creation. Otherwise, data will be updated using scheduler flow.

character affiliation is still updated on each authentication.