### PR TITLE
refactor(search): remove entity name from assets and skills search

### DIFF
--- a/src/resources/views/search/components/character_assets.blade.php
+++ b/src/resources/views/search/components/character_assets.blade.php
@@ -28,9 +28,9 @@
       serverSide  : true,
       ajax        : '{{ route('support.search.assets.data') }}',
       columns     : [
-        {data: 'character.name', name: 'character.name'},
-        {data: 'character.affiliation.corporation.name', name: 'character.affiliation.corporation.name'},
-        {data: 'character.affiliation.alliance.name', name: 'character.affiliation.alliance.name'},
+        {data: 'character.name', name: 'character.name', 'searchable': false},
+        {data: 'character.affiliation.corporation.name', name: 'character.affiliation.corporation.name', 'searchable': false},
+        {data: 'character.affiliation.alliance.name', name: 'character.affiliation.alliance.name', 'searchable': false},
         {data: 'asset_name', name: 'asset_name'},
         {data: 'location_name', name: 'location_name'},
         {data: 'type.group.groupName', name: 'type.group.groupName'},

--- a/src/resources/views/search/components/skills.blade.php
+++ b/src/resources/views/search/components/skills.blade.php
@@ -26,9 +26,9 @@
       serverSide  : true,
       ajax        : '{{ route('support.search.skills.data') }}',
       columns     : [
-        {data: 'character.name', name: 'character.name'},
-        {data: 'character.affiliation.corporation.name', name: 'character.affiliation.corporation.name'},
-        {data: 'character.affiliation.alliance.name', name: 'character.affiliation.alliance.name'},
+        {data: 'character.name', name: 'character.name', 'searchable': false},
+        {data: 'character.affiliation.corporation.name', name: 'character.affiliation.corporation.name', 'searchable': false},
+        {data: 'character.affiliation.alliance.name', name: 'character.affiliation.alliance.name', 'searchable': false},
         {data: 'type.group.groupName', name: 'type.group.groupName'},
         {data: 'type.typeName', name: 'type.typeName'},
         {data: 'trained_skill_level', name: 'trained_skill_level'}


### PR DESCRIPTION
in order to make search engine more useful, remove character name, corporation name and alliance name from searched column into assets and skills.