### PR TITLE
feat(customlink): Initial implementation of custom sidebar links.

### DIFF
--- a/src/Http/Composers/Sidebar.php
+++ b/src/Http/Composers/Sidebar.php
@@ -51,8 +51,28 @@ class Sidebar extends AbstractMenu
     public function compose(View $view)
     {
 
-        // Grab the menu and sort it.
+        // Grab the menu.
         $menu = config('package.sidebar');
+
+        // Grab any custom links.
+        if (! is_null(setting('customlinks', true))) {
+            $custommenu = setting('customlinks', true);
+
+            foreach($custommenu as $node) {
+
+                // Build our menu node
+                $node_name = preg_replace('/\s+/', '', strtolower($node['name']));
+                $menu[$node_name] = [
+                    'name'          => $node['name'],
+                    'icon'          => $node['icon'],
+                    'route_segment' => 'custom',
+                    'route'         => $node['url'],
+                    'newtab'        => $node['newtab'],
+                ];
+            }
+        }
+
+        // Sort the menu.
         ksort($menu);
 
         // Return the sidebar with the loaded packages menus

--- a/src/Http/Controllers/Configuration/SeatController.php
+++ b/src/Http/Controllers/Configuration/SeatController.php
@@ -112,9 +112,9 @@ class SeatController extends Controller
     {
 
         // Retrieve the form data.
-        $names   = $request->input('customlink-name', []);
-        $urls    = $request->input('customlink-url', []);
-        $icons   = $request->input('customlink-icon', []);
+        $names = $request->input('customlink-name', []);
+        $urls = $request->input('customlink-url', []);
+        $icons = $request->input('customlink-icon', []);
         $newtabs = $request->input('customlink-newtab', []);
 
         // Process the form data.
@@ -127,7 +127,7 @@ class SeatController extends Controller
                 'newtab' => (bool) $newtabs[$key],
             ];
         }
-        
+
         // Update the setting
         setting(['customlinks', $customlinks], true);
 

--- a/src/Http/Routes/Configuration/Seat.php
+++ b/src/Http/Routes/Configuration/Seat.php
@@ -30,6 +30,11 @@ Route::get('/about', [
     'uses' => 'SeatController@getAbout',
 ]);
 
+Route::post('/update/customlink', [
+    'as'   => 'seat.update.customlink',
+    'uses' => 'SeatController@postUpdateCustomlink',
+]);
+
 Route::post('/update/settings', [
     'as'   => 'seat.update.settings',
     'uses' => 'SeatController@postUpdateSettings',

--- a/src/Http/Validation/Customlink.php
+++ b/src/Http/Validation/Customlink.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Http\Validation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class Customlink.
+ *
+ * @package Seat\Web\Http\Validation
+ */
+class Customlink extends FormRequest
+{
+    /**
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'customlink-name.*'   => 'string|required',
+            'customlink-url.*'    => 'url|required',
+            'customlink-icon.*'   => 'string|nullable',
+            'customlink-newtab.*' => 'boolean|required',
+        ];
+    }
+}

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -408,6 +408,9 @@ return [
     'tracking_id'                  => 'Unique Tracking ID',
     'tracking_help'                => 'Before disabling the usage tracking, please refer to the below' .
         ' document first.',
+    'customlink'                   => 'Custom Links',
+    'customlink_description'       => 'You can add custom links to the SeAT sidebar menu here. You can optionally specify an ' . 
+        'icon to use from the Font Awesome free icons (eg. "fas fa-link").',
 
     // SSO Settings
     'sso_scopes'                   => 'SSO Scopes',

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -409,7 +409,7 @@ return [
     'tracking_help'                => 'Before disabling the usage tracking, please refer to the below' .
         ' document first.',
     'customlink'                   => 'Custom Links',
-    'customlink_description'       => 'You can add custom links to the SeAT sidebar menu here. You can optionally specify an ' . 
+    'customlink_description'       => 'You can add custom links to the SeAT sidebar menu here. You can optionally specify an ' .
         'icon to use from the Font Awesome free icons (eg. "fas fa-link").',
 
     // SSO Settings

--- a/src/resources/views/configuration/settings/view.blade.php
+++ b/src/resources/views/configuration/settings/view.blade.php
@@ -134,6 +134,53 @@
     </div>
   </div>
 
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">{{ trans('web::seat.customlink') }}</h3>
+    </div>
+    <div class="card-body">
+      <p>{{ trans('web::seat.customlink_description') }}</p>
+
+      <form role="form" action="{{ route('seat.update.customlink') }}" method="post">
+        {{ csrf_field() }}
+        <div class="row">
+          <span class="col-md-4">Name</span>
+          <span class="col">URL</span>
+          <span class="col-md-2">Icon</span>
+          <span class="col-md-2">New tab?</span>
+        </div>
+        <div id="customlinks">
+
+          @foreach($customlinks as $node)
+
+          <div class="form-row align-items-center my-1" id="customlink{{ $loop->index }}">
+            <div class="col-md-4">
+              <input type="text" class="form-control" name="customlink-name[]" value="{{ $node['name'] }}" />
+            </div>
+            <div class="col">
+              <input type="text" class="form-control" name="customlink-url[]" value="{{ $node['url'] }}" />
+            </div>
+            <div class="col-md-2">
+              <input type="text" class="form-control" name="customlink-icon[]" value="{{ $node['icon'] }}" />
+            </div>
+            <div class="col-md-2 form-inline">
+              <select class="form-control" name="customlink-newtab[]">
+                <option value="1" {{ ($node['newtab'] === false) ? '' : 'selected="selected"' }}>Yes</option>
+                <option value="0" {{ ($node['newtab'] === false) ? 'selected="selected"' : '' }}>No</option>
+              </select>
+              <button type="button" class="btn btn-danger btn-md ml-2" id="customlink-remove-btn" onclick="customlink_remove(this)"><i class="fas fa-trash"></i></button>
+            </div>
+          </div>
+
+          @endforeach
+        </div>
+
+        <button type="button" class="btn btn-link" id="customlink-add-btn"><i class="fas fa-plus"></i> Add new link</button>
+        <button type="submit" class="btn btn-primary">Update</button>
+      </form>
+    </div>
+  </div>
+
 @stop
 
 @section('right')
@@ -220,6 +267,38 @@
 
 @push('javascript')
 <script type="text/javascript">
+
+  var cloneIndex = $("#customlinks").length;
+  var customlink_template = '<div class="col-md-4">' +
+    '<input type="text" class="form-control" name="customlink-name[]" />' +
+    '</div>' +
+    '<div class="col">' +
+    '<input type="text" class="form-control" name="customlink-url[]" />' +
+    '</div>' +
+    '<div class="col-md-2">' +
+    '<input type="text" class="form-control" name="customlink-icon[]" />' +
+    '</div>'+
+    '<div class="col-md-2 form-inline">' +
+    '<select class="form-control" name="customlink-newtab[]">' +
+    '<option value="1" selected="selected">Yes</option>' +
+    '<option value="0">No</option>' +
+    '</select>' +
+    '<button type="button" class="btn btn-danger btn-md ml-2" id="customlink-remove-btn" onclick="customlink_remove(this)"><i class="fas fa-trash"></i></button>' +
+    '</div>';
+
+  $('#customlink-add-btn').on('click', function() {
+    cloneIndex++;
+    var div1 = document.createElement('div');
+    div1.id = 'customlink' + cloneIndex;
+    div1.className += 'form-row align-items-center my-1';
+    div1.innerHTML = customlink_template;
+    document.getElementById('customlinks').appendChild(div1);
+  });
+
+  function customlink_remove(ele) {
+    $(ele).parent().parent().remove();
+  }
+
   $(document).ready(function () {
     var market_prices_region = $('#market_prices_region');
     market_prices_region.select2({

--- a/src/resources/views/includes/sidebar.blade.php
+++ b/src/resources/views/includes/sidebar.blade.php
@@ -170,6 +170,16 @@
               </ul>
             </li>
 
+            {{-- render custom menu links --}}
+          @elseif($entry['route_segment'] === 'custom')
+
+          <li class="nav-item">
+              <a href="{{ $entry['route'] }}" class="nav-link" @if ($entry['newtab'] == true) target="_blank" @endif>
+                <i class="nav-icon {{ ($entry['icon'] != '') ? $entry['icon'] : 'fas fa-link' }}"></i>
+                <p>{{ $entry['name'] }}</p>
+              </a>
+            </li>
+
             {{-- no entries, so this looks like a single menu --}}
           @else
 


### PR DESCRIPTION
This PR closes eveseat/seat#605.

Adds a new option to SeAT settings page to add custom sidebar links. The sidebar links are stored in the global settings database table and are merged into the sidebar menu by the sidebar view composer (which sorts them alphabetically). 

Supports adding any number of links with the option to manually assign the Font Awesome icon class (refer to the Font Awesome site for list of free icons available).

![image](https://user-images.githubusercontent.com/8524371/79071778-e73a3b00-7d20-11ea-8291-4fa8b11b074b.png)

![image](https://user-images.githubusercontent.com/8524371/79071765-d5589800-7d20-11ea-9f0c-cf4c96c0b858.png)