### PR TITLE
Add SDE UI indicator of version match, add SDE to versions report.

### DIFF
--- a/src/resources/views/configuration/settings/view.blade.php
+++ b/src/resources/views/configuration/settings/view.blade.php
@@ -255,7 +255,7 @@
 
         <dt>
           <i id="live-sde-status" 
-            class="fa fa-question-circle text-orange"
+            class="fa fa-question-circle text-orange version-check"
             data-vendor="thirdparty"
             data-name="eve_online_sde"
             data-version="{{ setting('installed_sde', true) }}"
@@ -415,6 +415,10 @@
       installedPackages.vendor.push(toCheckPackage.attr('data-vendor'));
       installedPackages.name.push(toCheckPackage.attr('data-name'));
       installedPackages.version.push(toCheckPackage.attr('data-version'));
+
+      // skip third party checks
+      if (toCheckPackage.attr('data-vendor') == 'thirdparty')
+        return false;
 
       // send a request to check if or not a package is up-to-date
       $.ajax({

--- a/src/resources/views/configuration/settings/view.blade.php
+++ b/src/resources/views/configuration/settings/view.blade.php
@@ -253,7 +253,14 @@
 
       <dl>
 
-        <dt>Eve Online SDE</dt>
+        <dt>
+          <i id="live-sde-status" 
+            class="fa fa-question-circle text-orange"
+            data-vendor="thirdparty"
+            data-name="eve_online_sde"
+            data-version="{{ setting('installed_sde', true) }}"
+            data-toggle="tooltip"
+            title="Checking package status..."></i> Eve Online SDE</dt>
         <dd>
           <ul>
             <li>{{ trans('web::seat.installed') }}: <b>{{ setting('installed_sde', true) }}</b></li>
@@ -340,6 +347,18 @@
         live_sde = data.version;
       }
       $('#live-sde-version img').attr('src', 'https://img.shields.io/badge/version-' + live_sde + '-blue.svg?style=flat-square');
+      if (live_sde != "error") {
+        var liveSdeStatus = $('#live-sde-status');
+        var liveSdeOutdated = (live_sde != liveSdeStatus.attr('data-version')) ? true : false;
+        // remove pending state from the status
+        liveSdeStatus.removeClass('fa-question-circle');
+        liveSdeStatus.removeClass('text-orange');
+        // update state according to result
+        liveSdeStatus.addClass(liveSdeOutdated ? 'fa-times-circle' : 'fa-check-circle');
+        liveSdeStatus.addClass(liveSdeOutdated ? 'text-red' : 'text-green');
+        liveSdeStatus.attr('title', liveSdeOutdated ? 'At least one new version has been released !' : 'The package is up-to-date.');
+        liveSdeStatus.attr('data-original-title', liveSdeOutdated ? 'At least one new version has been released !' : 'The package is up-to-date.');
+      }
     });
 
     copyVersions.on('click', function() {


### PR DESCRIPTION
Adds checkmark UI icon next to SDE version similar to rest of SeAT modules and plugins:
![image](https://user-images.githubusercontent.com/8524371/79088555-4e3e0b00-7d86-11ea-917b-da52f0174e3c.png)

Also includes in version report when copied to clipboard:
```
| Vendor     | Package Name   | Installed Version        |
| ---------- | -------------- | ------------------------ |
| eveseat    | api            | 3.0.8                    |
| eveseat    | console        | 3.0.5                    |
| eveseat    | eveapi         | 3.0.17                   |
| eveseat    | notifications  | 3.0.6                    |
| eveseat    | services       | 3.0.10                   |
| eveseat    | web            | 4.0.0-dev                |
| thirdparty | eve_online_sde | sde-20200330-TRANQUILITY |
```

Closes eveseat/seat#521 and eveseat/seat#524.