### PR TITLE
enhance sso: ability to define scope profiles

### DIFF
--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -79,6 +79,17 @@ class LoginController extends Controller
         if (strlen(config('eveapi.config.eseye_client_secret')) < 5 || strlen(config('eveapi.config.eseye_client_id')) < 5)
             session()->flash('warning', trans('web::seat.sso_config_warning'));
 
-        return view('web::auth.login');
+        // Sign in message text
+        $custom_signin_message = setting('custom_signin_message', true);
+        $signin_message = trans('web::seat.login_welcome') . '<div class="box-body text-center"><a href="' . route('auth.eve') . '"><img src="' . asset('web/img/evesso.png') . '" alt="LOG IN with EVE Online"></a></div>';
+        if($custom_signin_message != '') {
+            // Look for patterns we can use as login buttons and swap them for the login links.
+            $pattern = '/([[]{2})([a-zA-Z0-9-_]+)([]]{2})/';
+            $signin_message = preg_replace_callback($pattern, function ($matches) {
+                return '<div class="box-body text-center"><a href="' . route('auth.eve.profile', $matches[2]) . '"><img src="' . asset('web/img/evesso.png') . '" alt="LOG IN with EVE Online"></a></div>';
+            }, $custom_signin_message);
+        }
+
+        return view('web::auth.login', compact('signin_message'));
     }
 }

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -63,7 +63,7 @@ class SsoController extends Controller
         } else {
             // Get the scopes that are marked as the default.
             $scopes = $scopes_setting->first(function ($item) {
-                return $item->name == "default";
+                return $item->name == 'default';
             });
         }
 

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -54,7 +54,7 @@ class SsoController extends Controller
 
         // Get the scopes that are marked as the default.
         $scopes = $scopes_setting->first(function ($item) {
-            return $item->name == 'default';
+            return $item->default == true;
         });
 
         if(! is_null($profile)) {

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -52,6 +52,11 @@ class SsoController extends Controller
 
         $scopes_setting = collect(setting('sso_scopes', true));
 
+        // Get the scopes that are marked as the default.
+        $scopes = $scopes_setting->first(function ($item) {
+            return $item->name == 'default';
+        });
+
         if(! is_null($profile)) {
             $scopes = $scopes_setting->first(function ($item) use ($profile) {
                 return $item->name == $profile;
@@ -60,11 +65,6 @@ class SsoController extends Controller
             // Invalid profile name?
             if(is_null($scopes))
                 abort(400);
-        } else {
-            // Get the scopes that are marked as the default.
-            $scopes = $scopes_setting->first(function ($item) {
-                return $item->name == 'default';
-            });
         }
 
         // Store the scopes we are sending to CCP in the session so we can

--- a/src/Http/Controllers/Configuration/SsoController.php
+++ b/src/Http/Controllers/Configuration/SsoController.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Http\Controllers\Configuration;
 
 use Illuminate\Http\Request;
 use Seat\Web\Http\Controllers\Controller;
+use Seat\Web\Http\Validation\CustomSignin;
 use Seat\Web\Http\Validation\SsoScopes;
 
 /**
@@ -50,7 +51,9 @@ class SsoController extends Controller
             });
         }
 
-        return view('web::configuration.sso.view', compact('selected_profile'));
+        $custom_signin_message = setting('custom_signin_message', true);
+
+        return view('web::configuration.sso.view', compact('selected_profile', 'custom_signin_message'));
     }
 
     /**
@@ -157,6 +160,22 @@ class SsoController extends Controller
         $scopes = $scopes->except($deleteKey);
 
         setting(['sso_scopes', $scopes], true);
+
+        return redirect()->back()->with('success', trans('web::seat.updated'));
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Seat\Services\Exceptions\SettingException
+     */
+    public function postUpdateCustomSignin(CustomSignin $request)
+    {
+
+        $custom_signin_message = $request->input('message', '');
+
+        setting(['custom_signin_message', $custom_signin_message], true);
 
         return redirect()->back()->with('success', trans('web::seat.updated'));
     }

--- a/src/Http/Controllers/Configuration/SsoController.php
+++ b/src/Http/Controllers/Configuration/SsoController.php
@@ -67,15 +67,15 @@ class SsoController extends Controller
 
         // default profile cannot be renamed
         $default_profile = $scopes->first(function ($item) {
-            return $item->name == "default";
+            return $item->name == 'default';
         });
 
-        if($default_profile->id == $request->input('profile_id') && $request->input('profile_name') != "default")
+        if($default_profile->id == $request->input('profile_id') && $request->input('profile_name') != 'default')
             return redirect()->back()->with('error', 'Cannot rename default profile.');
 
         $scopes->transform(function ($item, $key) use ($request) {
             if($item->id == $request->input('profile_id')) {
-                $item->name   = $request->input('profile_name');
+                $item->name = $request->input('profile_name');
                 $item->scopes = $request->input('scopes');
             }
 
@@ -120,13 +120,13 @@ class SsoController extends Controller
 
         // default profile cannot be removed
         $default_profile = $scopes->first(function ($item) {
-            return $item->name == "default";
+            return $item->name == 'default';
         });
 
         if($default_profile->id == $id)
             return redirect()->back()->with('error', 'Cannot remove default profile.');
 
-        $deleteKey = $scopes->search(function($item, $key) use ($id) {
+        $deleteKey = $scopes->search(function ($item, $key) use ($id) {
             return $item->id == $id;
         });
 

--- a/src/Http/Controllers/Configuration/SsoController.php
+++ b/src/Http/Controllers/Configuration/SsoController.php
@@ -40,14 +40,13 @@ class SsoController extends Controller
 
         $sso_scopes = collect(setting('sso_scopes', true));
 
-        $selected_profile = $request->input('profile', null);
-        if(! is_null($selected_profile)) {
-            $selected_profile = $sso_scopes->first(function ($item) use ($selected_profile) {
-                return $item->id == $selected_profile;
-            });
-        } else {
-            $selected_profile = $sso_scopes->first(function ($item) {
-                return $item->name == 'default';
+        $selected_profile = $sso_scopes->first(function ($item) {
+            return $item->name == 'default';
+        });
+
+        if(! is_null($request->input('profile', null))) {
+            $selected_profile = $sso_scopes->first(function ($item) use ($request) {
+                return $item->id == $request->input('profile');
             });
         }
 

--- a/src/Http/Routes/Auth/Sso.php
+++ b/src/Http/Routes/Auth/Sso.php
@@ -25,6 +25,11 @@ Route::get('/eve', [
     'uses' => 'SsoController@redirectToProvider',
 ]);
 
+Route::get('/eve/profile/{profile?}', [
+    'as'   => 'auth.eve.profile',
+    'uses' => 'SsoController@redirectToProvider',
+]);
+
 Route::get('/eve/callback', [
     'as'   => 'auth.eve.callback',
     'uses' => 'SsoController@handleProviderCallback',

--- a/src/Http/Routes/Configuration/Sso.php
+++ b/src/Http/Routes/Configuration/Sso.php
@@ -20,7 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-Route::get('/', [
+Route::match(['get', 'post'], '/', [
     'as'   => 'configuration.sso',
     'uses' => 'SsoController@getConfigurationHome',
 ]);
@@ -30,12 +30,12 @@ Route::post('/update-scopes', [
     'uses' => 'SsoController@postUpdateScopes',
 ]);
 
-Route::get('/enable-all', [
-    'as'   => 'configuration.sso.enable_all',
-    'uses' => 'SsoController@getEnableAll',
+Route::get('/add-profile', [
+    'as'   => 'configuration.sso.add_profile',
+    'uses' => 'SsoController@getAddProfile',
 ]);
 
-Route::get('/remove-all', [
-    'as'   => 'configuration.sso.remove_all',
-    'uses' => 'SsoController@getRemoveAll',
+Route::get('/delete-profile/{id}', [
+    'as'   => 'configuration.sso.delete_profile',
+    'uses' => 'SsoController@getDeleteProfile',
 ]);

--- a/src/Http/Routes/Configuration/Sso.php
+++ b/src/Http/Routes/Configuration/Sso.php
@@ -44,3 +44,8 @@ Route::get('/delete-profile/{id}', [
     'as'   => 'configuration.sso.delete_profile',
     'uses' => 'SsoController@getDeleteProfile',
 ]);
+
+Route::post('/update-custom-signin', [
+    'as'   => 'configuration.sso.update_custom_signin',
+    'uses' => 'SsoController@postUpdateCustomSignin',
+]);

--- a/src/Http/Routes/Configuration/Sso.php
+++ b/src/Http/Routes/Configuration/Sso.php
@@ -30,6 +30,11 @@ Route::post('/update-scopes', [
     'uses' => 'SsoController@postUpdateScopes',
 ]);
 
+Route::get('/set-default-profile/{id}', [
+    'as'   => 'configuration.sso.set_default_profile',
+    'uses' => 'SsoController@getSetDefaultProfile',
+]);
+
 Route::get('/add-profile', [
     'as'   => 'configuration.sso.add_profile',
     'uses' => 'SsoController@getAddProfile',

--- a/src/Http/Validation/CustomSignin.php
+++ b/src/Http/Validation/CustomSignin.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Http\Validation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class CustomSignin.
+ * @package Seat\Web\Http\Validation
+ */
+class CustomSignin extends FormRequest
+{
+    /**
+     * Authorize the request by default.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+
+        return [
+            'message'   => [
+                'nullable',
+                function ($attribute, $value, $fail) {
+                    $pattern = '/([[]{2})([a-zA-Z0-9-_]+)([]]{2})/';
+                    if(preg_match($pattern, $value) === 0)
+                        $fail('Missing a login button.');
+                },
+            ],
+        ];
+    }
+}

--- a/src/Http/Validation/SsoScopes.php
+++ b/src/Http/Validation/SsoScopes.php
@@ -51,7 +51,9 @@ class SsoScopes extends FormRequest
     {
 
         return [
-            'scopes.*' => ['required', Rule::in(config('eveapi.scopes'))],
+            'profile_id'   => 'required|integer',
+            'profile_name' => 'required|alpha_dash',
+            'scopes.*'     => ['required', Rule::in(config('eveapi.scopes'))],
         ];
     }
 }

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -435,6 +435,9 @@ return [
     'callback_maybe_wrong'         => 'Callback URL set but might be incorrect. Currently set as :current ' .
         'and should maybe be :suggested',
     'client_callback_not_ok'       => 'Callback URL not set. Check .env and set as :url',
+    'custom_signin_page'           => 'Customise Sign In page',
+    'custom_signin_page_desc'      => 'You can customise the message on the sign in page and insert links to your custom SSO scope ' .
+        'profiles as well. Leave blank to use the default. If you enter something below, you must ensure at least one button is shown.',
 
     // Updaters
     'update_dispatched'            => 'Update job has successfully been dispatched. Please check back again ' .

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -92,6 +92,7 @@ return [
     'read'                  => 'Read',
     'level'                 => 'Level',
     'token'                 => 'Token',
+    'set_default'           => 'Set Default',
 
     // Requirements
     'requirements'          => 'Requirements',
@@ -416,6 +417,8 @@ return [
 
     // SSO Settings
     'sso_scopes'                   => 'SSO Scopes',
+    'sso_scopes_profile_name'      => 'Profile Name',
+    'sso_scopes_profile_name_help' => 'You may use alpha-numeric characters along with hypens and underscores.',
     'available_scopes'             => 'Available SSO Scopes',
     'enable_all'                   => 'Enable All',
     'remove_all'                   => 'Remove All',

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -12,15 +12,15 @@
 
   <div class="login-box-body">
     <p class="login-box-msg">
-      {{ trans('web::seat.login_welcome') }}
+      {!! $signin_message !!}
     </p>
 
     <!-- SSO Button! -->
-    <div class="box-body text-center">
+    <!-- <div class="box-body text-center">
       <a href="{{ route('auth.eve') }}">
         <img src="{{ asset('web/img/evesso.png') }}">
       </a>
-    </div>
+    </div> -->
     <!-- /.box-footer -->
 
   </div>

--- a/src/resources/views/configuration/sso/view.blade.php
+++ b/src/resources/views/configuration/sso/view.blade.php
@@ -37,6 +37,9 @@
       </h3>
       <div class="card-tools">
         <div class="input-group input-group-sm btn-group btn-group-sm">
+          <a href="{{ route('configuration.sso.set_default_profile', $selected_profile->id) }}" id="set_default" class="btn btn-sm btn-info">
+            {{ trans('web::seat.set_default') }}
+          </a>
           <button role="button" id="enable_all" class="btn btn-sm btn-primary">
             {{ trans('web::seat.enable_all') }}
           </button>
@@ -57,7 +60,7 @@
           <div class="col-12">
             <div class="form-group">
               <label for="profile_name">{{ trans('web::seat.sso_scopes_profile_name') }}</label>
-              <input type="text" name="profile_name" id="profile_name" class="form-control" value="{{ $selected_profile->name }}" {{ ($selected_profile->name == "default") ? 'readonly' : '' }} />
+              <input type="text" name="profile_name" id="profile_name" class="form-control" value="{{ $selected_profile->name }}" />
               <small class="form-text text-muted">{{ trans('web::seat.sso_scopes_profile_name_help') }}</small>
             </div>
           </div>

--- a/src/resources/views/configuration/sso/view.blade.php
+++ b/src/resources/views/configuration/sso/view.blade.php
@@ -9,16 +9,40 @@
   <div class="card card-default">
     <div class="card-header">
       <h3 class="card-title">
+        {{ trans('web::seat.profile') }}
+      </h3>
+    </div>
+
+    <div class="card-body">
+      <form role="form" id="profile" action="{{ route('configuration.sso') }}" method="post">
+        {{ csrf_field() }}
+        <div class="form-group row">
+          <label for="available_profiles">{{ trans('web::seat.profile') }}</label>
+          <select name="profile" id="available_profiles" class="custom-select">
+            @foreach(setting('sso_scopes', true) as $scope)
+            <option value="{{ $scope->id }}" {{ ($scope->id == $selected_profile->id) ? 'selected' : ''}}>{{ $scope->name }}</option>
+            @endforeach
+          </select>
+        </div>
+      </form>
+      <a href="{{ route('configuration.sso.add_profile') }}" class="btn btn-primary"><i class="fas fa-plus"></i> Add new Profile</a>
+      <a href="{{ route('configuration.sso.delete_profile', $selected_profile->id) }}" class="btn btn-danger"><i class="fas fa-trash"></i> Delete Profile</a>
+    </div>
+  </div>
+  
+  <div class="card card-default">
+    <div class="card-header">
+      <h3 class="card-title">
         {{ trans('web::seat.sso_scopes') }}
       </h3>
       <div class="card-tools">
         <div class="input-group input-group-sm btn-group btn-group-sm">
-          <a href="{{ route('configuration.sso.enable_all') }}" class="btn btn-sm btn-primary">
+          <button role="button" id="enable_all" class="btn btn-sm btn-primary">
             {{ trans('web::seat.enable_all') }}
-          </a>
-          <a href="{{ route('configuration.sso.remove_all') }}" class="btn btn-sm btn-danger">
+          </button>
+          <button role="button" id="remove_all" class="btn btn-sm btn-danger">
             {{ trans('web::seat.remove_all') }}
-          </a>
+          </button>
         </div>
       </div>
     </div>
@@ -27,6 +51,17 @@
 
       <form role="form" action="{{ route('configuration.sso.update_scopes') }}" method="post">
         {{ csrf_field() }}
+        <input type="hidden" name="profile_id" id="profile_id" value="{{ $selected_profile->id }}" />
+
+        <div class="row">
+          <div class="col-12">
+            <div class="form-group">
+              <label for="profile_name">{{ trans('web::seat.sso_scopes_profile_name') }}</label>
+              <input type="text" name="profile_name" id="profile_name" class="form-control" value="{{ $selected_profile->name }}" {{ ($selected_profile->name == "default") ? 'readonly' : '' }} />
+              <small class="form-text text-muted">{{ trans('web::seat.sso_scopes_profile_name_help') }}</small>
+            </div>
+          </div>
+        </div>
 
         <div class="row">
           <div class="col-12">
@@ -37,7 +72,7 @@
 
                 @foreach(config('eveapi.scopes') as $scope)
 
-                  <option value="{{ $scope }}" @if (! is_null(setting('sso_scopes', true)) && in_array($scope, setting('sso_scopes', true))) selected @endif>
+                  <option value="{{ $scope }}" @if (! is_null($selected_profile->scopes) && in_array($scope, $selected_profile->scopes)) selected @endif>
                     {{ $scope }}
                   </option>
 
@@ -120,6 +155,20 @@
 
   <script>
     $("#available_scopes").select2();
+
+    $("#available_profiles").change(function () {
+      $("#profile").trigger("submit");
+    });
+
+    $("#enable_all").click(function() {
+      $("#available_scopes > option").prop("selected","selected");
+      $("#available_scopes").trigger("change");
+    });
+
+    $("#remove_all").click(function() {
+      $("#available_scopes > option").removeAttr("selected");
+      $("#available_scopes").trigger("change");
+    });
   </script>
 
 @endpush


### PR DESCRIPTION
This PR adds support for defining multiple SSO scope profiles in the settings to allow different access levels depending on the type of user joining SeAT - for example different scope profiles for corporation, alliance and public.

Profiles are accessed using the route auth.eve.profile with the parameter of the profile name. Examples:
/auth/eve (for default profile, route via alias: `route('auth.eve')`)
/auth/eve/profile/alliance (for a profile named alliance, route via alias: `route('auth.eve.profile', 'alliance')`)

Default profile: 
![image](https://user-images.githubusercontent.com/8524371/80865787-e4eb5100-8cce-11ea-8970-81f7f45e048b.png)

Custom profile example: 
![image](https://user-images.githubusercontent.com/8524371/80865812-02201f80-8ccf-11ea-9793-7b5cae893f5f.png) 

This may address and close eveseat/seat#382 - although the control over scopes stays with the SeAT administrator rather then the user, this allows extra flexibility that I think addresses the reason for requesting this capability.