### PR TITLE
fix: datatables scopes for character and corporations

### DIFF
--- a/src/Http/DataTables/Scopes/CharacterScope.php
+++ b/src/Http/DataTables/Scopes/CharacterScope.php
@@ -88,7 +88,7 @@ class CharacterScope implements DataTableScope
             ->flatten()
             ->filter(function ($permission) {
                 if (empty($this->ability))
-                    return strpos('character.', $permission->title) === 0;
+                    return strpos($permission->title, 'character.') === 0;
 
                 return $permission->title == $this->ability;
             });

--- a/src/Http/DataTables/Scopes/CorporationScope.php
+++ b/src/Http/DataTables/Scopes/CorporationScope.php
@@ -88,7 +88,7 @@ class CorporationScope implements DataTableScope
             ->flatten()
             ->filter(function ($permission) {
                 if (empty($this->ability))
-                    return strpos('corporation.', $permission->title) === 0;
+                    return strpos($permission->title, 'corporation.') === 0;
 
                 return $permission->title == $this->ability;
             });


### PR DESCRIPTION
PHP function strpos used for permissions checks had needle and haystack wrong way around so it was returning no permissions to be checked, resulting in only the users own characters being returned (unless a super user).