### PR TITLE
Adding production environment to horizon config

### DIFF
--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -311,6 +311,16 @@ class WebServiceProvider extends AbstractSeatPlugin
                     'timeout'    => 900, // 15 minutes
                 ],
             ],
+            'production' => [
+                'seat-workers' => [
+                    'connection' => 'redis',
+                    'queue'      => ['high', 'medium', 'low', 'default'],
+                    'balance'    => $balancing_mode,
+                    'processes'  => (int) env(self::QUEUE_BALANCING_WORKERS, 4),
+                    'tries'      => 1,
+                    'timeout'    => 900, // 15 minutes
+                ],
+            ],
         ];
 
         // Set the environment configuration.


### PR DESCRIPTION
Hello,

i propose to add production environment to horizon config.

currently, workers are not running with APP_ENV=production

thanks.