### PR TITLE
fix(search): switch search engine to new ACL

### DIFF
--- a/src/Http/Controllers/Support/SearchController.php
+++ b/src/Http/Controllers/Support/SearchController.php
@@ -23,7 +23,6 @@
 namespace Seat\Web\Http\Controllers\Support;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
 use Seat\Eveapi\Models\Character\CharacterInfo;

--- a/src/Http/DataTables/Scopes/CharacterMailScope.php
+++ b/src/Http/DataTables/Scopes/CharacterMailScope.php
@@ -46,7 +46,7 @@ class CharacterMailScope implements DataTableScope
      *
      * @param int[]|null $character_ids
      */
-    public function __construct(?array $character_ids)
+    public function __construct(?array $character_ids = null)
     {
         $this->requested_characters = $character_ids;
     }


### PR DESCRIPTION
when user attempt to search a data, he receive error modals from assets, corporations, characters and skills table.

Closes eveseat/seat#635