### PR TITLE
fix: remove default value on field message

### DIFF
--- a/src/database/migrations/2019_12_15_104132_create_squad_applications_table.php
+++ b/src/database/migrations/2019_12_15_104132_create_squad_applications_table.php
@@ -40,7 +40,7 @@ class CreateSquadApplicationsTable extends Migration
             $table->bigIncrements('application_id');
             $table->integer('user_id')->unsigned();
             $table->integer('squad_id')->unsigned()->unique();
-            $table->text('message')->default('');
+            $table->text('message');
             $table->timestamps();
 
             $table->index('squad_id');


### PR DESCRIPTION
MySQL does not support extended default value. As a result, previous migration version was not able to be executed on versions up to 8.0.21.