### PR TITLE
Initial squad permission

### DIFF
--- a/src/Config/package.sidebar.php
+++ b/src/Config/package.sidebar.php
@@ -67,6 +67,7 @@ return [
     'squads'      => [
         'name'          => 'squads',
         'label'         => 'web::squads.squad',
+        'permission'    => 'global.squads',
         'plural'        => true,
         'icon'          => 'fas fa-user-friends',
         'route_segment' => 'squads',


### PR DESCRIPTION
Create menu permission for squads menu item. Should only be available for members intended.