### PR TITLE
refactor: reduce datatables generated uri length

### DIFF
--- a/src/Http/Controllers/Tools/MoonsController.php
+++ b/src/Http/Controllers/Tools/MoonsController.php
@@ -64,11 +64,11 @@ class MoonsController extends Controller
             Moon::EXCEPTIONAL => trans('web::moons.exceptional'),
         ];
 
-        $region_id = intval(request()->query('region_id', 0));
-        $constellation_id = intval(request()->query('constellation_id', 0));
-        $system_id = intval(request()->query('system_id', 0));
-        $rank_selection = request()->query('rank_selection', []);
-        $product_selection = request()->query('product_selection', []);
+        $region_id = intval(request()->input('region_id', 0));
+        $constellation_id = intval(request()->input('constellation_id', 0));
+        $system_id = intval(request()->input('system_id', 0));
+        $rank_selection = request()->input('rank_selection', []);
+        $product_selection = request()->input('product_selection', []);
 
         if ($region_id != 0)
             $dataTable->addScope(new RegionScope($region_id));

--- a/src/Http/DataTables/Character/Financial/ContractDataTable.php
+++ b/src/Http/DataTables/Character/Financial/ContractDataTable.php
@@ -46,7 +46,7 @@ class ContractDataTable extends AbstractContractDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Financial/MarketDataTable.php
+++ b/src/Http/DataTables/Character/Financial/MarketDataTable.php
@@ -46,7 +46,7 @@ class MarketDataTable extends AbstractMarketDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Financial/WalletJournalDataTable.php
+++ b/src/Http/DataTables/Character/Financial/WalletJournalDataTable.php
@@ -46,7 +46,7 @@ class WalletJournalDataTable extends AbstractWalletJournalDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Financial/WalletTransactionDataTable.php
+++ b/src/Http/DataTables/Character/Financial/WalletTransactionDataTable.php
@@ -46,7 +46,7 @@ class WalletTransactionDataTable extends AbstractWalletTransactionDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Industrial/Blueprints/DataTable.php
+++ b/src/Http/DataTables/Character/Industrial/Blueprints/DataTable.php
@@ -51,7 +51,7 @@ class DataTable extends AbstractBlueprintDataTable
     {
         return parent::html()
             ->removeColumn('location_flag')
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Industrial/IndustryDataTable.php
+++ b/src/Http/DataTables/Character/Industrial/IndustryDataTable.php
@@ -46,7 +46,7 @@ class IndustryDataTable extends AbstractIndustryDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(), d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Industrial/MiningDataTable.php
+++ b/src/Http/DataTables/Character/Industrial/MiningDataTable.php
@@ -60,7 +60,7 @@ class MiningDataTable extends AbstractMiningDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Industrial/PlanetaryInteractionDataTable.php
+++ b/src/Http/DataTables/Character/Industrial/PlanetaryInteractionDataTable.php
@@ -49,6 +49,7 @@ class PlanetaryInteractionDataTable extends DataTable
     public function html()
     {
         return $this->builder()
+            ->postAjax()
             ->columns($this->getColumns());
     }
 

--- a/src/Http/DataTables/Character/Industrial/ResearchDataTable.php
+++ b/src/Http/DataTables/Character/Industrial/ResearchDataTable.php
@@ -64,12 +64,11 @@ class ResearchDataTable extends DataTable
     public function html()
     {
         return $this->builder()
-            ->postAjax()
             ->columns($this->getColumns())
             ->parameters([
                 'drawCallback' => 'function() { $("[data-toggle=tooltip]").tooltip(); }',
             ])
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Intel/Assets/DataTable.php
+++ b/src/Http/DataTables/Character/Intel/Assets/DataTable.php
@@ -64,7 +64,7 @@ class DataTable extends AbstractAssetDataTable
     {
         return parent::html()
             ->removeColumn('location_flag')
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Intel/BookmarkDataTable.php
+++ b/src/Http/DataTables/Character/Intel/BookmarkDataTable.php
@@ -46,7 +46,7 @@ class BookmarkDataTable extends AbstractBookmarkDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Intel/CalendarDataTable.php
+++ b/src/Http/DataTables/Character/Intel/CalendarDataTable.php
@@ -80,9 +80,8 @@ class CalendarDataTable extends DataTable
     public function html()
     {
         return $this->builder()
-            ->postAjax()
             ->columns($this->getColumns())
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ])
             ->parameters([

--- a/src/Http/DataTables/Character/Intel/ContactDataTable.php
+++ b/src/Http/DataTables/Character/Intel/ContactDataTable.php
@@ -46,7 +46,7 @@ class ContactDataTable extends AbstractContactDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Intel/NotificationDataTable.php
+++ b/src/Http/DataTables/Character/Intel/NotificationDataTable.php
@@ -68,12 +68,11 @@ class NotificationDataTable extends DataTable
     public function html()
     {
         return $this->builder()
-            ->postAjax()
             ->columns($this->getColumns())
             ->parameters([
                 'drawCallback' => 'function() { $("[data-toggle=tooltip]").tooltip(); $("[data-toggle=popover]").popover(); ids_to_names(); }',
             ])
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Military/FittingDataTable.php
+++ b/src/Http/DataTables/Character/Military/FittingDataTable.php
@@ -52,7 +52,7 @@ class FittingDataTable extends AbstractFittingDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Military/KillMailDataTable.php
+++ b/src/Http/DataTables/Character/Military/KillMailDataTable.php
@@ -37,7 +37,7 @@ class KillMailDataTable extends AbstractKillMailDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Character/Military/StandingDataTable.php
+++ b/src/Http/DataTables/Character/Military/StandingDataTable.php
@@ -46,7 +46,7 @@ class StandingDataTable extends AbstractStandingDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.characters = $("#dt-character-selector").val(); }',
             ]);
     }

--- a/src/Http/DataTables/Common/Intel/AbstractAssetDataTable.php
+++ b/src/Http/DataTables/Common/Intel/AbstractAssetDataTable.php
@@ -98,6 +98,7 @@ abstract class AbstractAssetDataTable extends DataTable
     public function html()
     {
         return $this->builder()
+            ->postAjax()
             ->columns($this->getColumns())
             ->orderBy(0, 'asc')
             ->addAction();

--- a/src/Http/DataTables/Configuration/RolesDataTable.php
+++ b/src/Http/DataTables/Configuration/RolesDataTable.php
@@ -69,6 +69,7 @@ class RolesDataTable extends DataTable
     public function html()
     {
         return $this->builder()
+            ->postAjax()
             ->columns($this->getColumns())
             ->addAction();
     }

--- a/src/Http/DataTables/Corporation/Financial/ContractDataTable.php
+++ b/src/Http/DataTables/Corporation/Financial/ContractDataTable.php
@@ -46,7 +46,7 @@ class ContractDataTable extends AbstractContractDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Corporation/Financial/MarketDataTable.php
+++ b/src/Http/DataTables/Corporation/Financial/MarketDataTable.php
@@ -45,8 +45,9 @@ class MarketDataTable extends AbstractMarketDataTable
      */
     public function html()
     {
-        return parent::html()->ajax([
-            'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
-        ]);
+        return parent::html()
+            ->postAjax([
+                'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
+            ]);
     }
 }

--- a/src/Http/DataTables/Corporation/Industrial/Blueprints/DataTable.php
+++ b/src/Http/DataTables/Corporation/Industrial/Blueprints/DataTable.php
@@ -50,9 +50,10 @@ class DataTable extends AbstractBlueprintDataTable
      */
     public function html()
     {
-        return parent::html()->ajax([
-            'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
-        ]);
+        return parent::html()
+            ->postAjax([
+                'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
+            ]);
     }
 
     /**

--- a/src/Http/DataTables/Corporation/Industrial/IndustryDataTable.php
+++ b/src/Http/DataTables/Corporation/Industrial/IndustryDataTable.php
@@ -45,8 +45,9 @@ class IndustryDataTable extends AbstractIndustryDataTable
      */
     public function html()
     {
-        return parent::html()->ajax([
-            'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
-        ]);
+        return parent::html()
+            ->postAjax([
+                'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
+            ]);
     }
 }

--- a/src/Http/DataTables/Corporation/Intel/ContactDataTable.php
+++ b/src/Http/DataTables/Corporation/Intel/ContactDataTable.php
@@ -46,7 +46,7 @@ class ContactDataTable extends AbstractContactDataTable
     public function html()
     {
         return parent::html()
-            ->ajax([
+            ->postAjax([
                 'data' => 'function(d) { d.filters = {}; $("[data-filter-field].dt-filters.active").each(function (i, e) { var a = $(e); var field = a.data("filter-field"); var value = a.data("filter-value"); if (! d.filters[field]) { d.filters[field] = []; } d.filters[field].push(value); }); }',
             ]);
     }

--- a/src/Http/DataTables/Tools/MoonsDataTable.php
+++ b/src/Http/DataTables/Tools/MoonsDataTable.php
@@ -88,13 +88,12 @@ class MoonsDataTable extends DataTable
     {
         return $this->builder()
             ->dom('Brtip')
-            ->postAjax()
             ->columns($this->getColumns())
             ->addAction()
             ->parameters([
                 'drawCallback' => 'function(settings) { ids_to_names(); $(".moon-stats .badge-success").text(settings.json.stats.ubiquitous); $(".moon-stats .badge-primary").text(settings.json.stats.common); $(".moon-stats .badge-info").text(settings.json.stats.uncommon); $(".moon-stats .badge-warning").text(settings.json.stats.rare); $(".moon-stats .badge-danger").text(settings.json.stats.exceptional); $(".moon-stats .badge-default").text(settings.json.stats.standard); }',
             ])
-            ->ajax([
+            ->postAjax([
                 'data' => 'function (d) {
                     d.region_id         = $("#dt-filters-region").val() === null ? 0 : $("#dt-filters-region").val();
                     d.constellation_id  = $("#dt-filters-constellation").val() === null ? 0 : $("#dt-filters-constellation").val();


### PR DESCRIPTION
Prevent reverse proxy and old browsers to bounce generated URI.
This especially impact IIS:

> When a query string is received by IIS that is longer than 2048 characters, IIS throws a 404.15 - Query String too long error . A value of 2083 characters is the maximum URL length for Internet Explorer by default, and an 404.14 – URL too long error is thrown when a longer URL is requested.