### PR TITLE
fix(squads): use title unique id instead of corp title id

### DIFF
--- a/src/Http/Controllers/Support/FastLookupController.php
+++ b/src/Http/Controllers/Support/FastLookupController.php
@@ -109,25 +109,25 @@ class FastLookupController extends Controller
      */
     public function getTitles(Request $request)
     {
-
         if ($request->query('_type', 'query') == 'find') {
             $title = CorporationTitle::find($request->query('q', 1));
 
             return response()->json([
-                'id' => $title->title_id,
-                'text' => strip_tags($title->name),
+                'id'   => $title->id,
+                'text' => sprintf('%s (%s)', strip_tags($title->name), $title->corporation->name),
             ]);
         }
 
-     $titles = CorporationTitle::where('name', 'like', '%' . $request->query('q', '') . '%')
-          ->orderBy('name')
-          ->get()
-          ->map(function ($title) {
-           return [
-               'id' => $title->title_id,
-               'text' =>  strip_tags($title->name),
-           ];
-      });
+        $titles = CorporationTitle::with('corporation')
+            ->where('name', 'like', '%' . $request->query('q', '') . '%')
+            ->orderBy('name')
+            ->get()
+            ->map(function ($title) {
+                return [
+                    'id'   => $title->id,
+                    'text' => sprintf('%s (%s)', strip_tags($title->name), $title->corporation->name),
+                ];
+            });
 
         return response()->json([
             'results' => $titles,

--- a/src/resources/views/squads/create.blade.php
+++ b/src/resources/views/squads/create.blade.php
@@ -59,7 +59,7 @@
   @include('web::components.filters.modals.filters.filters', [
     'filters' => [
         (object) ['name' => 'character', 'src' => route('fastlookup.characters'), 'path' => 'characters', 'field' => 'character_infos.character_id', 'label' => 'Character'],
-        (object) ['name' => 'title', 'src' => route('fastlookup.titles'), 'path' => 'characters.titles', 'field' => 'title_id', 'label' => 'Title'],
+        (object) ['name' => 'title', 'src' => route('fastlookup.titles'), 'path' => 'characters.titles', 'field' => 'id', 'label' => 'Title'],
         (object) ['name' => 'corporation', 'src' => route('fastlookup.corporations'), 'path' => 'characters.affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
         (object) ['name' => 'alliance', 'src' => route('fastlookup.alliances'), 'path' => 'characters.affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
         (object) ['name' => 'skill', 'src' => route('fastlookup.skills'), 'path' => 'characters.skills', 'field' => 'skill_id', 'label' => 'Skill'],

--- a/src/resources/views/squads/edit.blade.php
+++ b/src/resources/views/squads/edit.blade.php
@@ -72,7 +72,7 @@
   @include('web::components.filters.modals.filters.filters', [
     'filters' => [
         (object) ['name' => 'character', 'src' => route('fastlookup.characters'), 'path' => 'characters', 'field' => 'character_infos.character_id', 'label' => 'Character'],
-        (object) ['name' => 'title', 'src' => route('fastlookup.titles'), 'path' => 'characters.titles', 'field' => 'title_id', 'label' => 'Title'],
+        (object) ['name' => 'title', 'src' => route('fastlookup.titles'), 'path' => 'characters.titles', 'field' => 'id', 'label' => 'Title'],
         (object) ['name' => 'corporation', 'src' => route('fastlookup.corporations'), 'path' => 'characters.affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
         (object) ['name' => 'alliance', 'src' => route('fastlookup.alliances'), 'path' => 'characters.affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
         (object) ['name' => 'skill', 'src' => route('fastlookup.skills'), 'path' => 'characters.skills', 'field' => 'skill_id', 'label' => 'Skill'],


### PR DESCRIPTION
**CRITICAL HOTFIX**
this is a critical hotfix - wrong pivot field were used to make the relation between a corporation title and the title owned by a character.

**you must update all squads which use title filter**
1) edit the squad
2) open filters
3) remove existing title rules and update them
