### PR TITLE
feat: classified squads

### DIFF
--- a/src/Acl/Policies/SquadPolicy.php
+++ b/src/Acl/Policies/SquadPolicy.php
@@ -118,7 +118,8 @@ class SquadPolicy
      */
     public function show_members(User $user, Squad $squad)
     {
-        return $squad->members->where('id', $user->id)->isNotEmpty() ||
+        return ($squad->members->where('id', $user->id)->isNotEmpty() &&
+            !$squad->is_classified) ||
             $squad->moderators->where('id', $user->id)->isNotEmpty();
     }
 

--- a/src/Http/Controllers/Squads/SquadsController.php
+++ b/src/Http/Controllers/Squads/SquadsController.php
@@ -106,11 +106,12 @@ class SquadsController extends Controller
     public function store(SquadValidation $request)
     {
         $squad = Squad::create([
-            'name'        => $request->input('name'),
-            'type'        => $request->input('type'),
-            'description' => $request->input('description'),
-            'filters'     => $request->input('filters'),
-            'logo'        => $request->file('logo'),
+            'name'          => $request->input('name'),
+            'type'          => $request->input('type'),
+            'description'   => $request->input('description'),
+            'filters'       => $request->input('filters'),
+            'is_classified' => $request->input('classified') == 'on',
+            'logo'          => $request->file('logo'),
         ]);
 
         return redirect()->route('squads.show', $squad->id)
@@ -136,6 +137,7 @@ class SquadsController extends Controller
         $squad->name = $request->input('name');
         $squad->type = $request->input('type');
         $squad->description = $request->input('description');
+        $squad->is_classified = $request->input('classified') == 'on';
         $squad->filters = $request->input('filters');
 
         if ($request->hasFile('logo'))

--- a/src/Models/Squads/Squad.php
+++ b/src/Models/Squads/Squad.php
@@ -53,6 +53,13 @@ class Squad extends Model
     /**
      * @var array
      */
+    protected $casts = [
+        'is_classified' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
     protected $hidden = [
         'applications', 'members',
     ];

--- a/src/database/migrations/2020_08_23_103135_create_classified_field_on_squads_table.php
+++ b/src/database/migrations/2020_08_23_103135_create_classified_field_on_squads_table.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class CreateSquadsTable.
+ */
+class CreateClassifiedFieldOnSquadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('squads', function (Blueprint $table) {
+            $table->boolean('is_classified')->after('filters')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('squads', function (Blueprint $table) {
+            $table->dropColumn('is_classified');
+        });
+    }
+}

--- a/src/resources/views/squads/create.blade.php
+++ b/src/resources/views/squads/create.blade.php
@@ -43,7 +43,7 @@
                     <input type="checkbox" name="classified" id="squad-classified" class="form-check-input ml-0" />
                   </div>
                   <div class="col-sm-10">
-                    <div>If a squad is classified, then only moderators will be able to see the member list</div>
+                    <div>If a squad is classified, then only moderators and administrators will be able to see the member list</div>
                   </div>
                 </div>
                 <input type="hidden" name="description" />

--- a/src/resources/views/squads/create.blade.php
+++ b/src/resources/views/squads/create.blade.php
@@ -37,6 +37,15 @@
                     </select>
                   </div>
                 </div>
+                <div class="form-group row">
+                  <label for="squad-classified" class="col-sm-1 col-form-label">Classified?</label>
+                  <div class="col-sm-1">
+                    <input type="checkbox" name="classified" id="squad-classified" class="form-check-input ml-0" />
+                  </div>
+                  <div class="col-sm-10">
+                    <div>If a squad is classified, then only moderators will be able to see the member list</div>
+                  </div>
+                </div>
                 <input type="hidden" name="description" />
                 <input type="hidden" name="filters" />
                 <input type="file" name="logo" accept="image/png, image/jpeg" id="file-image" class="d-none" />

--- a/src/resources/views/squads/edit.blade.php
+++ b/src/resources/views/squads/edit.blade.php
@@ -60,7 +60,7 @@
                     @endif
                   </div>
                   <div class="col-sm-10">
-                    <div>If a squad is classified, then only moderators will be able to see the member list</div>
+                    <div>If a squad is classified, then only moderators and administrators will be able to see the member list</div>
                   </div>
                 </div>
                 <input type="hidden" name="description" value="{{ $squad->getOriginal('filters') }}" />

--- a/src/resources/views/squads/edit.blade.php
+++ b/src/resources/views/squads/edit.blade.php
@@ -50,6 +50,19 @@
                     </select>
                   </div>
                 </div>
+                <div class="form-group row">
+                  <label for="squad-classified" class="col-sm-1 col-form-label">Classified?</label>
+                  <div class="col-sm-1">
+                    @if($squad->is_classified)
+                      <input type="checkbox" name="classified" id="squad-classified" class="form-check-input ml-0" checked />
+                    @else
+                      <input type="checkbox" name="classified" id="squad-classified" class="form-check-input ml-0" />
+                    @endif
+                  </div>
+                  <div class="col-sm-10">
+                    <div>If a squad is classified, then only moderators will be able to see the member list</div>
+                  </div>
+                </div>
                 <input type="hidden" name="description" value="{{ $squad->getOriginal('filters') }}" />
                 <input type="hidden" name="filters" value="{{ $squad->filters }}" />
                 <input type="file" name="logo" accept="image/png, image/jpeg" id="file-image" class="d-none" />

--- a/src/resources/views/squads/show.blade.php
+++ b/src/resources/views/squads/show.blade.php
@@ -217,6 +217,7 @@
     </div>
   @endcan
 
+  @if(!$squad->is_classified or $squad->getIsModeratorAttribute() or auth()->user()->isAdmin())
   <div class="row">
     <div class="col-12">
       <div class="card">
@@ -262,6 +263,7 @@
       </div>
     </div>
   </div>
+  @endif
 
   @can('squads.manage_candidates', $squad)
     @if($squad->type == 'manual' && $squad->moderators->isNotEmpty())

--- a/src/resources/views/squads/show.blade.php
+++ b/src/resources/views/squads/show.blade.php
@@ -217,7 +217,7 @@
     </div>
   @endcan
 
-  @if(!$squad->is_classified or $squad->getIsModeratorAttribute() or auth()->user()->isAdmin())
+  @can('squads.show_members', $squad)
   <div class="row">
     <div class="col-12">
       <div class="card">
@@ -263,7 +263,7 @@
       </div>
     </div>
   </div>
-  @endif
+  @endcan
 
   @can('squads.manage_candidates', $squad)
     @if($squad->type == 'manual' && $squad->moderators->isNotEmpty())


### PR DESCRIPTION
Add the ability to hide a squad member list. A squad marked as classified will only show the member list for moderators and admins.

I got delayed so have the merge commit in here... Not sure if thats ideal or not...