### PR TITLE
fix(ui): use contact table to determine category

### DIFF
--- a/src/Http/DataTables/Common/Intel/AbstractContactDataTable.php
+++ b/src/Http/DataTables/Common/Intel/AbstractContactDataTable.php
@@ -44,7 +44,7 @@ abstract class AbstractContactDataTable extends DataTable
                 return view('web::partials.standing', ['standing' => $row->standing])->render();
             })
             ->editColumn('entity.name', function ($row) {
-                switch ($row->entity->category) {
+                switch ($row->contact_type) {
                     case 'alliance':
                         return view('web::partials.alliance', ['alliance' => $row->entity])->render();
                     case 'corporation':

--- a/src/Http/DataTables/Scopes/Filters/ContactCategoryScope.php
+++ b/src/Http/DataTables/Scopes/Filters/ContactCategoryScope.php
@@ -57,8 +57,6 @@ class ContactCategoryScope implements DataTableScope
      */
     public function apply($query)
     {
-        return $query->whereHas('entity', function ($sub_query) {
-            return $sub_query->whereIn('category', $this->categories);
-        });
+        return $query->whereIn('contact_type', $this->categories);
     }
 }


### PR DESCRIPTION
since we may not know exact contact identity, prefer using contact category rather than identity category in order to filter contacts results.