### PR TITLE
Refactor total SP stats to use all associated character IDs on homepage

### DIFF
--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -58,7 +58,7 @@ class HomeController extends Controller
         // TODO : switch to ajax calls
         $server_status = $this->getEveLastServerStatus();
         $total_character_isk = $this->getTotalCharacterIsk(auth()->user()->associatedCharacterIds());
-        $total_character_skillpoints = $this->getTotalCharacterSkillpoints(auth()->user()->main_character_id);
+        $total_character_skillpoints = $this->getTotalCharacterSkillpoints(auth()->user()->associatedCharacterIds());
         $total_character_killmails = $this->getTotalCharacterKillmails(auth()->user()->associatedCharacterIds());
         $total_character_mining = $this->getTotalCharacterMiningIsk(auth()->user()->associatedCharacterIds());
 

--- a/src/Traits/Stats.php
+++ b/src/Traits/Stats.php
@@ -67,10 +67,10 @@ trait Stats
      * @param int $character_id
      * @return int
      */
-    public function getTotalCharacterSkillpoints(int $character_id): ?int
+    public function getTotalCharacterSkillpoints(array $character_ids): ?int
     {
 
-        return CharacterInfoSkill::where('character_id', $character_id)
+        return CharacterInfoSkill::whereIn('character_id', $character_ids)
             ->sum('total_sp');
     }
 


### PR DESCRIPTION
The getTotalSP method is only used on the homepage so I assume it is safe to refactor like this. 

Related to eveseat/seat#673