### PR TITLE
refactor: remove entity name from redis cache

### DIFF
--- a/src/resources/views/partials/alliance.blade.php
+++ b/src/resources/views/partials/alliance.blade.php
@@ -1,8 +1,9 @@
 @if(! is_null($alliance) && (! is_null($alliance->entity_id) || ! is_null($alliance->alliance_id)))
-  {!! img('alliances', 'logo', $alliance->alliance_id ?? $alliance->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
-  {!!
-    cache(sprintf('name_id:%s', $alliance->alliance_id ?? $alliance->entity_id), function () use ($alliance) {
-      return sprintf('<span class="id-to-name" data-id="%d">%s</span>', $alliance->alliance_id ?? $alliance->entity_id, trans('web::seat.unknown'));
-    })
-  !!}
+  @if($alliance->name)
+      {!! img('alliances', 'logo', $alliance->alliance_id ?? $alliance->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+      <span>{{ $alliance->name }}</span>
+  @else
+    {!! img('alliances', 'logo', $alliance->alliance_id ?? $alliance->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+    <span class="id-to-name" data-id="{{ $alliance->alliance_id ?? $alliance->entity_id }}">{{ trans('web::seat.unknown') }}</span>
+  @endif
 @endif

--- a/src/resources/views/partials/character.blade.php
+++ b/src/resources/views/partials/character.blade.php
@@ -1,13 +1,16 @@
 @if ($character->name && $character->name !== trans('web::seat.unknown'))
-  <a href="{{ route('character.view.default', ['character' => $character->character_id ?? $character->entity_id]) }}">
-    {!! img('characters', 'portrait', $character->character_id ?? $character->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
-    {{ $character->name }}
-  </a>
+  @if(\Seat\Eveapi\Models\Character\CharacterInfo::find($character->character_id ?? $character->entity_id))
+    <a href="{{ route('character.view.default', ['character' => $character->character_id ?? $character->entity_id]) }}">
+      {!! img('characters', 'portrait', $character->character_id ?? $character->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+      {{ $character->name }}
+    </a>
+  @else
+    <span>
+      {!! img('characters', 'portrait', $character->character_id ?? $character->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+      {{ $character->name }}
+    </span>
+  @endif
 @else
   {!! img('characters', 'portrait', $character->character_id ?? $character->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
-  {!!
-    cache(sprintf('name_id:%s', $character->character_id ?? $character->entity_id), function () use ($character) {
-      return sprintf('<span class="id-to-name" data-id="%d">%s</span>', $character->character_id ?? $character->entity_id, trans('web::seat.unknown'));
-    })
-  !!}
+  <span class="id-to-name" data-id="{{ $character->character_id ?? $character->entity_id }}">{{ trans('web::seat.unknown') }}</span>
 @endif

--- a/src/resources/views/partials/corporation.blade.php
+++ b/src/resources/views/partials/corporation.blade.php
@@ -1,13 +1,16 @@
 @if ($corporation->name && $corporation->name !== trans('web::seat.unknown'))
+  @if(\Seat\Eveapi\Models\Corporation\CorporationInfo::find($corporation->corporation_id ?? $corporation->entity_id))
   <a href="{{ route('corporation.view.default', ['corporation' => $corporation->corporation_id ?? $corporation->entity_id]) }}">
     {!! img('corporations', 'logo', $corporation->corporation_id ?? $corporation->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
     {{ $corporation->name }}
   </a>
+  @else
+    <span>
+      {!! img('corporations', 'logo', $corporation->corporation_id ?? $corporation->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+      {{ $corporation->name }}
+    </span>
+  @endif
 @else
   {!! img('corporations', 'logo', $corporation->corporation_id ?? $corporation->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
-  {!!
-    cache(sprintf('name_id:%s', $corporation->corporation_id ?? $corporation->entity_id), function () use ($corporation) {
-      return sprintf('<span class="id-to-name" data-id="%d">%s</span>', $corporation->corporation_id ?? $corporation->entity_id, trans('web::seat.unknown'));
-    })
-  !!}
+  <span class="id-to-name" data-id="{{ $corporation->corporation_id ?? $corporation->entity_id }}">{{ trans('web::seat.unknown') }}</span>
 @endif


### PR DESCRIPTION
Remove entity name from cache and link only entity from which we own data.

Closes eveseat/seat#669