### PR TITLE
fix(ui): add token check on character summary

### DIFF
--- a/src/resources/views/character/includes/summary.blade.php
+++ b/src/resources/views/character/includes/summary.blade.php
@@ -3,8 +3,20 @@
     <h3 class="card-title">{{ trans('web::seat.summary') }}</h3>
     <div class="card-tools">
       @if(! is_null($character->refresh_token))
+        @if($character->refresh_token->updated_at->lt(carbon()->subDay()))
+          <span class="text-warning">
+            <i class="fas fa-exclamation-circle" data-toggle="tooltip" title="Token has not been updated since more than a day, you should check your jobs."></i>
+          </span>
+        @else
+          <span class="text-success">
+            <i class="fas fa-check-circle" data-toggle="tooltip" title="This character has a valid registered token."></i>
+          </span>
+        @endif
         <span class="badge badge-secondary">{{ $character->refresh_token->user->characters->count() }}</span>
       @else
+        <span class="text-danger">
+          <i class="fas fa-times-circle" data-toggle="tooltip" title="You don't own any valid token for this character."></i>
+        </span>
         <span class="badge badge-secondary">0</span>
       @endif
     </div>


### PR DESCRIPTION
Add a small check on the character summary header, next to user character counter.
The icon can have 3 states :
 - valid, it's a green mark
 - suspect, it's a warning exclamation point
 - invalid, it's a red cross

Each state show a small tooltip while beeing hovered.

![image](https://user-images.githubusercontent.com/648753/97080105-57434b00-15f9-11eb-9f00-a7a68664fbac.png)


Closes eveseat/seat#694