### PR TITLE
fix(acl): request proper permission while generating corporation menu

### DIFF
--- a/src/Config/package.corporation.menu.php
+++ b/src/Config/package.corporation.menu.php
@@ -96,7 +96,7 @@ return [
     [
         'name'           => 'customs-offices',
         'label'          => 'web::seat.customs-offices',
-        'permission'     => 'corporation.customs-office',
+        'permission'     => 'corporation.customs_office',
         'highlight_view' => 'customs-offices',
         'route'          => 'corporation.view.customs_offices',
     ],


### PR DESCRIPTION
a typo in the used permission requested to display "Custom Offices" entry was generating an invalid entry in security logs and prevent user other than admin to access this view even with proper permission.

Closes eveseat/seat#703