### PR TITLE
fix(squads): retrieve search keyword when changing page

### DIFF
--- a/src/resources/views/squads/list.blade.php
+++ b/src/resources/views/squads/list.blade.php
@@ -198,7 +198,7 @@
 
       $(document)
           .on('click', '.pagination a', function(e) {
-              var keyword = $('input[name="search-squad]').val();
+              var keyword = $('input[name="search-squad"]').val();
               e.preventDefault();
 
               $('.pagination li').removeClass('active');


### PR DESCRIPTION
a typo in the event in charge of refreshing squads cards was preventing search keywords to be forward when user attempt to change page.

Closes eveseat/seat#706