### PR TITLE
feat(squads): add ability to restrict by skill level

### DIFF
--- a/src/database/migrations/2020_12_05_105939_upgrade_squads_maj4_min3_hf1.php
+++ b/src/database/migrations/2020_12_05_105939_upgrade_squads_maj4_min3_hf1.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Seat\Web\Models\Squads\Squad;
+use Seat\Web\Models\User;
+
+/**
+ * Class UpgradeSquadsMaj4Min3Hf1.
+ */
+class UpgradeSquadsMaj4Min3Hf1 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Squad::where('type', 'auto')->get()->each(function ($squad) {
+            User::chunk(100, function ($users) use ($squad) {
+                $users->each(function ($user) use ($squad) {
+                    $is_member = $squad->whereDoesntHave('members', function ($query) use ($user) {
+                        $query->where('id', $user->id);
+                    });
+
+                    if ($is_member && ! $squad->isEligible($user))
+                        $squad->members()->detach($user->id);
+
+                    if (! $is_member && $squad->isEligible($user))
+                        $squad->members()->attach($user->id);
+                });
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/src/resources/views/components/filters/modals/filters/filters.blade.php
+++ b/src/resources/views/components/filters/modals/filters/filters.blade.php
@@ -53,6 +53,11 @@
 
 @push('javascript')
   <script>
+    function isUrl(s) {
+      var regexp = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
+      return regexp.test(s);
+    }
+
     function buildFilters(source)
     {
         var filters = {};
@@ -99,6 +104,27 @@
 
         $(e.target).closest('.card').find('.card-body').first().append(rule);
       })
+      .on('change', '.rule-type', function () {
+          let criteria = $(this).closest('.form-row').find('.rule-criteria');
+          let src = $('option:selected', $(this)).data('src');
+
+          // determine the filter type (closed list or lookup)
+          if (isUrl(src)) {
+              criteria.select2({
+                  dropdownParent: $('#filters-modal'),
+                  ajax: {
+                      url: function () {
+                          return src;
+                      }
+                  }
+              });
+          } else {
+              criteria.select2({
+                  dropdownParent: $('#filters-modal'),
+                  data: src
+              });
+          }
+      })
       .on('click', '.btn-ruleset', function (e) {
         var group = $('#ruleset-template').clone();
         group.removeAttr('id');
@@ -141,30 +167,42 @@
 
                   node.find('.rule-operator').val(rule.operator);
 
-                  type = node.find('.rule-type');
-                  criteria = node.find('.rule-criteria');
+                  let type = node.find('.rule-type');
+                  let criteria = node.find('.rule-criteria');
 
                   type.val(rule.name);
 
-                  criteria.select2({
-                      dropdownParent: $('#filters-modal'),
-                      ajax: {
-                          url: function () {
-                              return $('option:selected', type).data('src');
+                  // determine the filter type (closed list or lookup)
+                  if (isUrl($('option:selected', type).data('src'))) {
+                      criteria.select2({
+                          dropdownParent: $('#filters-modal'),
+                          ajax: {
+                              url: function () {
+                                  return $('option:selected', type).data('src');
+                              }
                           }
-                      }
-                  });
+                      });
 
-                  criteria.append(new Option(rule.text, rule.criteria, true, true)).trigger('change');
-                  criteria.trigger({
-                      type: 'select2:select',
-                      params: {
-                          data: {
-                              text: rule.text,
-                              id: rule.criteria
-                          },
-                      }
-                  });
+                      criteria.append(new Option(rule.text, rule.criteria, true, true)).trigger('change');
+
+                      criteria.trigger({
+                          type: 'select2:select',
+                          params: {
+                              data: {
+                                  text: rule.text,
+                                  id: rule.criteria
+                              },
+                          }
+                      });
+                  } else {
+                      criteria.select2({
+                          dropdownParent: $('#filters-modal'),
+                          data: $('option:selected', type).data('src')
+                      });
+
+                      criteria.val(rule.criteria);
+                      criteria.trigger('change');
+                  }
 
                   modal.append(node);
               }
@@ -186,30 +224,42 @@
 
                           node.find('.rule-operator').val(ruleset_rule.operator);
 
-                          type = node.find('.rule-type');
-                          criteria = node.find('.rule-criteria');
+                          let type = node.find('.rule-type');
+                          let criteria = node.find('.rule-criteria');
 
                           type.val(ruleset_rule.name);
 
-                          criteria.select2({
-                              dropdownParent: $('#filters-modal'),
-                              ajax: {
-                                  url: function () {
-                                      return $('option:selected', type).data('src');
+                          // determine the filter type (closed list or lookup)
+                          if (isUrl($('option:selected', type).data('src'))) {
+                              criteria.select2({
+                                  dropdownParent: $('#filters-modal'),
+                                  ajax: {
+                                      url: function () {
+                                          return $('option:selected', type).data('src');
+                                      }
                                   }
-                              }
-                          });
+                              });
 
-                          criteria.append(new Option(ruleset_rule.text, ruleset_rule.criteria, true, true)).trigger('change');
-                          criteria.trigger({
-                              type: 'select2:select',
-                              params: {
-                                  data: {
-                                      text: ruleset_rule.text,
-                                      id: ruleset_rule.criteria
-                                  },
-                              }
-                          });
+                              criteria.append(new Option(ruleset_rule.text, ruleset_rule.criteria, true, true)).trigger('change');
+
+                              criteria.trigger({
+                                  type: 'select2:select',
+                                  params: {
+                                      data: {
+                                          text: ruleset_rule.text,
+                                          id: ruleset_rule.criteria
+                                      },
+                                  }
+                              });
+                          } else {
+                              criteria.select2({
+                                  dropdownParent: $('#filters-modal'),
+                                  data: $('option:selected', type).data('src')
+                              });
+
+                              criteria.val(ruleset_rule.criteria);
+                              criteria.trigger('change');
+                          }
 
                           ruleset.find('.card-body').append(node);
                       });

--- a/src/resources/views/components/filters/modals/filters/rule.blade.php
+++ b/src/resources/views/components/filters/modals/filters/rule.blade.php
@@ -5,7 +5,7 @@
       <label>Type</label>
       <select class="form-control rule-type">
         @foreach($filters as $filter)
-          <option value="{{ $filter->name }}" data-src="{{ $filter->src }}" data-path="{{ $filter->path }}" data-field="{{ $filter->field }}">{{ $filter->label }}</option>
+          <option value="{{ $filter->name }}" data-src="{{ is_array($filter->src) ? json_encode($filter->src) : $filter->src }}" data-path="{{ $filter->path }}" data-field="{{ $filter->field }}">{{ $filter->label }}</option>
         @endforeach
       </select>
     </div>
@@ -14,6 +14,8 @@
       <select class="form-control rule-operator">
         <option value="=">Is</option>
         <option value="<>">Is Not</option>
+        <option value=">">Is Greater Than</option>
+        <option value="<">Is Less Than</option>
         <option value="contains">Contains</option>
       </select>
     </div>

--- a/src/resources/views/squads/create.blade.php
+++ b/src/resources/views/squads/create.blade.php
@@ -73,6 +73,7 @@
         (object) ['name' => 'corporation', 'src' => route('fastlookup.corporations'), 'path' => 'characters.affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
         (object) ['name' => 'alliance', 'src' => route('fastlookup.alliances'), 'path' => 'characters.affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
         (object) ['name' => 'skill', 'src' => route('fastlookup.skills'), 'path' => 'characters.skills', 'field' => 'skill_id', 'label' => 'Skill'],
+        (object) ['name' => 'skill_level', 'src' => [['id' => 1, 'text' => 'Level 1'], ['id' => 2, 'text' => 'Level 2'], ['id' => 3, 'text' => 'Level 3'], ['id' => 4, 'text' => 'Level 4'], ['id' => 5, 'text' => 'Level 5']], 'path' => 'characters.skills', 'field' => 'trained_skill_level', 'label' => 'Skill Level'],
         (object) ['name' => 'type', 'src' => route('fastlookup.items'), 'path' => 'characters.assets', 'field' => 'type_id', 'label' => 'Item'],
     ],
   ])

--- a/src/resources/views/squads/edit.blade.php
+++ b/src/resources/views/squads/edit.blade.php
@@ -90,6 +90,7 @@
         (object) ['name' => 'corporation', 'src' => route('fastlookup.corporations'), 'path' => 'characters.affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
         (object) ['name' => 'alliance', 'src' => route('fastlookup.alliances'), 'path' => 'characters.affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
         (object) ['name' => 'skill', 'src' => route('fastlookup.skills'), 'path' => 'characters.skills', 'field' => 'skill_id', 'label' => 'Skill'],
+        (object) ['name' => 'skill_level', 'src' => [['id' => 1, 'text' => 'Level 1'], ['id' => 2, 'text' => 'Level 2'], ['id' => 3, 'text' => 'Level 3'], ['id' => 4, 'text' => 'Level 4'], ['id' => 5, 'text' => 'Level 5']], 'path' => 'characters.skills', 'field' => 'trained_skill_level', 'label' => 'Skill Level'],
         (object) ['name' => 'type', 'src' => route('fastlookup.items'), 'path' => 'characters.assets', 'field' => 'type_id', 'label' => 'Item'],
     ],
   ])


### PR DESCRIPTION
revamp the filter pattern to allow to pair rules by relation paths.
this allow to define a filter based on both skill name and skill level.

Closes eveseat/seat#693