### PR TITLE
 fix: prevent exception when user change main character related to an existing account

### DIFF
--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -715,6 +715,10 @@ return [
     'standings_builder'            => 'Standings Builder',
     'moons_reporter'               => 'Moons Reporter',
 
+    // Error pages
+    'duplicate_account'            => 'Duplicate Account',
+    'duplicate_account_msg'        => 'We are unable to proceed your change. The character :name is already used in another account. Please contact your administrator to regulate the situation.',
+
     // Footer
     'web_version'                  => 'Web Version',
     'docker_version'               => 'Docker Version',

--- a/src/resources/views/error.blade.php
+++ b/src/resources/views/error.blade.php
@@ -1,0 +1,16 @@
+@extends('web::layouts.app-mini')
+
+@section('content')
+    <div class="error-page">
+      <h3 class="text-uppercase text-danger" style="margin-left: 120px;">{{ $error_name }}</h3>
+      <hr/>
+      <h2 class="headline text-danger float-left" style="font-size: 100px;">
+        <i class="far fa-frown"></i>
+      </h2>
+      <div style="margin-left: 120px;">
+        <p class="text-muted text-justify font-italic">{{ $error_message }}</p>
+        <a href="{{ url()->previous() }}" class="btn btn-danger">
+          <i class="fas fa-arrow-circle-left"></i> Go back</a>
+      </div>
+    </div>
+@stop

--- a/src/resources/views/profile/view.blade.php
+++ b/src/resources/views/profile/view.blade.php
@@ -17,25 +17,6 @@
 
           <legend>{{ trans('web::seat.user_interface') }}</legend>
 
-          @if(auth()->user()->name != 'admin')
-          <!-- Select Basic -->
-          <div class="form-group row">
-            <label class="col-md-4 col-form-label"
-                   for="main_character_id">{{ trans('web::seat.main_character') }}</label>
-            <div class="col-md-6">
-              <select id="main_character_id" name="main_character_id" class="form-control" style="width: 100%;">
-                @foreach($characters as $character)
-                  <option value="{{ $character->character_id }}"
-                          @if(setting('main_character_id') == $character->id)
-                          selected
-                      @endif>
-                    {{ $character->name }}</option>
-                @endforeach
-              </select>
-            </div>
-          </div>
-          @endif
-
           <!-- Select Basic -->
           <div class="form-group row">
             <label class="col-md-4 col-form-label" for="skin">{{ trans('web::seat.seat_skin') }}</label>


### PR DESCRIPTION
instead showing an system exception, attempt to retrieve user account related to the newly selected main character.

if there is one, attempt to remove it. We can remove an account if he has no more keys attached to it. If the target character is still related to an account with keys, display a nice error message to assist end user.

Closes eveseat/seat#708