### PR TITLE
fix(acl): log to security logs only on displayed page

### DIFF
--- a/src/Acl/Policies/AbstractPolicy.php
+++ b/src/Acl/Policies/AbstractPolicy.php
@@ -37,12 +37,19 @@ abstract class AbstractPolicy
     const CACHE_DURATION = 10;
 
     /**
+     * @var string
+     */
+    protected $ability;
+
+    /**
      * @param \Seat\Web\Models\User $user
      * @param string $ability
      * @return bool|void
      */
     public function before(User $user, $ability)
     {
+        $this->ability = $ability;
+
         if ($user->isAdmin())
             return true;
     }

--- a/src/Acl/Response.php
+++ b/src/Acl/Response.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Acl;
+
+/**
+ * Class Response.
+ *
+ * @package Seat\Web\Acl
+ */
+class Response extends \Illuminate\Auth\Access\Response
+{
+    /**
+     * @return \Seat\Web\Acl\Response
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize()
+    {
+        if ($this->denied())
+            event('security.log', [$this->message(), 'authorization']);
+
+        return parent::authorize();
+    }
+}

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -435,14 +435,6 @@ class WebServiceProvider extends AbstractSeatPlugin
                 Gate::define($ability, sprintf('%s@%s', $policy, $permission));
             }
         }
-
-        Gate::after(function ($user, $ability, $result, $arguments) {
-            if (! $result) {
-                $message = sprintf('Request to %s was denied. The permission required is %s', request()->path(), $ability);
-
-                event('security.log', [$message, 'authorization']);
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
log to security logs only if the user is asking for a page to which he does not have access to due to missing privileges.
currently, we're logging all acl events, including conditional display which is not expected.