### PR TITLE
fix: swap the htmlentity for a single-quote back to actual character.

### DIFF
--- a/src/resources/views/search/components/character.blade.php
+++ b/src/resources/views/search/components/character.blade.php
@@ -32,7 +32,7 @@
         ids_to_names();
       },
       'search'    : {
-        'search': '{{ $query }}'
+        'search': '{{ $query }}'.replace('&#039;', '\'')
       },
       order       : [[0, "asc"]]
     });

--- a/src/resources/views/search/components/character_assets.blade.php
+++ b/src/resources/views/search/components/character_assets.blade.php
@@ -42,7 +42,7 @@
         ids_to_names();
       },
       'search'    : {
-        'search': '{{ $query }}'
+        'search': '{{ $query }}'.replace('&#039;', '\'')
       },
       order       : [[0, "asc"]]
     });

--- a/src/resources/views/search/components/corporation.blade.php
+++ b/src/resources/views/search/components/corporation.blade.php
@@ -36,7 +36,7 @@
         ids_to_names();
       },
       'search'    : {
-        'search': '{{ $query }}'
+        'search': '{{ $query }}'.replace('&#039;', '\'')
       }
     });
   </script>

--- a/src/resources/views/search/components/mail.blade.php
+++ b/src/resources/views/search/components/mail.blade.php
@@ -42,7 +42,7 @@
         ids_to_names();
       },
       'search'    : {
-        'search': '{{ $query }}'
+        'search': '{{ $query }}'.replace('&#039;', '\'')
       },
       order       : [[0, "desc"]]
     });

--- a/src/resources/views/search/components/skills.blade.php
+++ b/src/resources/views/search/components/skills.blade.php
@@ -38,7 +38,7 @@
         ids_to_names();
       },
       'search'    : {
-        'search': '{{ $query }}'
+        'search': '{{ $query }}'.replace('&#039;', '\'')
       },
       order       : [[0, "asc"]]
     });


### PR DESCRIPTION
Swap the HTML entity for a single-quote back to the actual character in the search field. Blade will still apply `htmlspecialchars()` to the rest of the query string.

Closes eveseat/seat#482.