### PR TITLE
feat: admin view invalid tokens

### DIFF
--- a/src/Config/Permissions/global.php
+++ b/src/Config/Permissions/global.php
@@ -28,4 +28,8 @@ return [
         'label'       => 'web::permissions.global_standing_builder_label',
         'description' => 'web::permissions.global_standing_builder_description',
     ],
+    'invalid_tokens' => [
+        'label'       => 'web::permissions.global_invalid_tokens_label',
+        'description' => 'web::permissions.global_invalid_tokens_description',
+    ],
 ];

--- a/src/Http/Controllers/Profile/ProfileController.php
+++ b/src/Http/Controllers/Profile/ProfileController.php
@@ -52,7 +52,11 @@ class ProfileController extends Controller
         $history = auth()->user()->login_history->take(50)->sortByDesc('created_at');
 
         // Settings value possibilities
-        $characters = auth()->user()->characters;
+        if (auth()->user()->can('global.invalid_tokens')){
+            $characters = auth()->user()->all_characters();
+        } else {
+            $characters = auth()->user()->characters;
+        }
 
         // available languages
         $languages = config('web.locale.languages');

--- a/src/Http/DataTables/Configuration/UsersDataTable.php
+++ b/src/Http/DataTables/Configuration/UsersDataTable.php
@@ -105,6 +105,7 @@ class UsersDataTable extends DataTable
      */
     public function query()
     {
+        
         return User::with('characters', 'roles', 'roles.permissions')
             ->standard();
     }

--- a/src/Http/DataTables/Configuration/UsersDataTable.php
+++ b/src/Http/DataTables/Configuration/UsersDataTable.php
@@ -105,7 +105,6 @@ class UsersDataTable extends DataTable
      */
     public function query()
     {
-        
         return User::with('characters', 'roles', 'roles.permissions')
             ->standard();
     }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -155,6 +155,15 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     }
 
     /**
+     * @return \Illuminate\Database\Eloquent\Relations\
+     */
+    public function all_characters()
+    {
+
+        return CharacterInfo::whereIn('character_id', RefreshToken::withTrashed()->where('user_id', $this->id)->pluck('character_id'))->get();
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function main_character()

--- a/src/resources/lang/en/permissions.php
+++ b/src/resources/lang/en/permissions.php
@@ -37,11 +37,13 @@ return [
     // Global Scope
     'global_standing_builder_label'             => 'Grant access to the Standings Builder',
     'global_standing_builder_description'       => 'The Standings Builder shows an overview of your character, corporation and alliance standings. It is mainly used for exchanging standings between alliances of a coalition or corporations within an alliance. Also useful for character intel.',
+    'global_invalid_tokens_label'             => 'Grant access to see invalidated tokens',
+    'global_invalid_tokens_description'       => 'Showing invalid tokens allows you to see the characters associated with an account that are now invalid. Normally they are hidden.',
     'global_moons_reporter_label'               => 'Moon Reporter',
     'global_moons_reporter_description'         => 'The Moon Reporter can show all moons of New Eden and their registered composition reports.',
     'global_moons_reporter_manager_label'       => 'Moon Reports Manager',
     'global_moons_reporter_manager_description' => 'The Moon Reports Manager can create and update moon reports.',
-    'global_queue_manager_label'               => 'Queue Manager',
+    'global_queue_manager_label'                => 'Queue Manager',
 
     // Moon Reporter Scope
     'view_moon_reports_label'           => 'View Moon Reports',

--- a/src/resources/views/character/includes/summary.blade.php
+++ b/src/resources/views/character/includes/summary.blade.php
@@ -40,7 +40,8 @@
               {{ $character_info->name }}
             </a>
             @else
-            <a>
+            <a href="{{ route(\Illuminate\Support\Facades\Route::currentRouteName(),
+            array_merge(request()->route()->parameters, ['character' => $character_info])) }}">
               {!! img('characters', 'portrait', $character_info->character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
               {{ $character_info->name }}
             </a>

--- a/src/resources/views/character/includes/summary.blade.php
+++ b/src/resources/views/character/includes/summary.blade.php
@@ -28,12 +28,38 @@
 
     <ul class="list-group list-group-unbordered mb-3">
       @if(! is_null($character->refresh_token))
-        @foreach($character->refresh_token->user->characters->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
+        @can('global.invalid_tokens')
+          @foreach($character->refresh_token->user->all_characters()->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
+
+          <li class="list-group-item">
+
+            @if($character_info->refresh_token)
+            <a href="{{ route(\Illuminate\Support\Facades\Route::currentRouteName(),
+            array_merge(request()->route()->parameters, ['character' => $character_info])) }}">
+              {!! img('characters', 'portrait', $character_info->character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+              {{ $character_info->name }}
+            </a>
+            @else
+            <a>
+              {!! img('characters', 'portrait', $character_info->character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
+              {{ $character_info->name }}
+            </a>
+            <button data-toggle="tooltip" title="Invalid Token" class="btn btn-sm btn-link">
+                <i class="fa fa-exclamation-triangle text-danger"></i>
+              </button>
+            @endif
+
+            <span class="id-to-name text-muted float-right" data-id="{{ $character_info->affiliation->corporation_id }}">{{ $character_info->affiliation->corporation->name }}</span>
+          </li>
+
+          @endforeach
+        @else
+          @foreach($character->refresh_token->user->characters->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
 
           <li class="list-group-item">
 
             <a href="{{ route(\Illuminate\Support\Facades\Route::currentRouteName(),
-             array_merge(request()->route()->parameters, ['character' => $character_info])) }}">
+            array_merge(request()->route()->parameters, ['character' => $character_info])) }}">
               {!! img('characters', 'portrait', $character_info->character_id, 64, ['class' => 'img-circle eve-icon small-icon']) !!}
               {{ $character_info->name }}
             </a>
@@ -41,7 +67,8 @@
             <span class="id-to-name text-muted float-right" data-id="{{ $character_info->affiliation->corporation_id }}">{{ $character_info->affiliation->corporation->name }}</span>
           </li>
 
-        @endforeach
+          @endforeach
+        @endcan
       @endif
 
     </ul>

--- a/src/resources/views/configuration/users/edit.blade.php
+++ b/src/resources/views/configuration/users/edit.blade.php
@@ -91,29 +91,61 @@
 
       <ul class="list-group list-group-flush">
 
-        @foreach($user->characters as $character)
-          <li class="list-group-item">
+        @can('global.invalid_tokens')
 
-            @if ($character->refresh_token)
-              <button data-toggle="tooltip" title="Valid Token" class="btn btn-sm btn-link">
-                <i class="fa fa-check text-success"></i>
-              </button>
-            @else
-              <button data-toggle="tooltip" title="Invalid Token" class="btn btn-sm btn-link">
-                <i class="fa fa-exclamation-triangle text-danger"></i>
-              </button>
-            @endif
+          @foreach($user->all_characters() as $character)
+            <li class="list-group-item">
 
-            @if($character->refresh_token)
-              @include('web::profile.buttons.scopes')
-            @endif
+              @if ($character->refresh_token)
+                <button data-toggle="tooltip" title="Valid Token" class="btn btn-sm btn-link">
+                  <i class="fa fa-check text-success"></i>
+                </button>
+              @else
+                <button data-toggle="tooltip" title="Invalid Token" class="btn btn-sm btn-link">
+                  <i class="fa fa-exclamation-triangle text-danger"></i>
+                </button>
+              @endif
 
-            @include('web::configuration.users.buttons.transfer')
+              @if($character->refresh_token)
+                @include('web::profile.buttons.scopes')
+              @else
+                @include('web::profile.buttons.noscopes')
+              @endif
 
-            @include('web::partials.character', ['character' => $character])
+              @include('web::configuration.users.buttons.transfer')
 
-          </li>
-        @endforeach
+              @include('web::partials.character', ['character' => $character])
+
+            </li>
+          @endforeach
+
+        @else
+
+          @foreach($user->characters as $character)
+            <li class="list-group-item">
+
+              @if ($character->refresh_token)
+                <button data-toggle="tooltip" title="Valid Token" class="btn btn-sm btn-link">
+                  <i class="fa fa-check text-success"></i>
+                </button>
+              @else
+                <button data-toggle="tooltip" title="Invalid Token" class="btn btn-sm btn-link">
+                  <i class="fa fa-exclamation-triangle text-danger"></i>
+                </button>
+              @endif
+
+              @if($character->refresh_token)
+                @include('web::profile.buttons.scopes')
+              @endif
+
+              @include('web::configuration.users.buttons.transfer')
+
+              @include('web::partials.character', ['character' => $character])
+
+            </li>
+          @endforeach
+
+        @endcan
 
       </ul>
 

--- a/src/resources/views/profile/buttons/noscopes.blade.php
+++ b/src/resources/views/profile/buttons/noscopes.blade.php
@@ -1,0 +1,4 @@
+<button type="button" class="btn btn-link btn-sm disabled">
+  <i class="fas fa-shield-alt"></i>
+  {{ trans_choice('web::seat.scope', 2) }}
+</button>

--- a/src/resources/views/profile/view.blade.php
+++ b/src/resources/views/profile/view.blade.php
@@ -339,6 +339,8 @@
 
             @if($character->refresh_token)
               @include('web::profile.buttons.scopes')
+            @else
+              @include('web::profile.buttons.noscopes')
             @endif
 
             @if($character->refresh_token && setting('allow_user_character_unlink', true) == 'yes')


### PR DESCRIPTION
Allows for granting the `Invalid Tokens` permission. This permission allows for linked characters with invalid tokens to still be displayed.

Caveats:
1. Linked characters with invalid tokens will not appear in the Users datatable baubles.
2. Viewing a character with no refresh token will not show the linked characters