### PR TITLE
fix: migration fails due to malformed foreign key constraint in MariaDB

### DIFF
--- a/src/database/migrations/2021_01_17_150414_create_universe_moon_reports_table.php
+++ b/src/database/migrations/2021_01_17_150414_create_universe_moon_reports_table.php
@@ -38,7 +38,7 @@ class CreateUniverseMoonReportsTable extends Migration
     public function up()
     {
         Schema::create('universe_moon_reports', function (Blueprint $table) {
-            $table->integer('moon_id');
+            $table->integer('moon_id')->primary();
             $table->unsignedInteger('user_id');
             $table->timestamps();
         });


### PR DESCRIPTION
MariaDB doesn't accept a foreign key constraint unless the columns on both sides are the same type, including if one side is an index. The moon_id column in universe_moon_contents is an index, so the moon_id column in universe_moon_reports must be as well in order to have a foreign key constraint between the two.

Ref: https://blog.mariadb.org/mariadb-innodb-foreign-key-constraint-errors/