### PR TITLE
fix: Replace today's date with a string when no remap exists.

### DIFF
--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -548,6 +548,7 @@ return [
     'bonus_remaps'                 => 'Bonus Remaps',
     'last_remap_date'              => 'Last Remap Date',
     'accrued_remap_cooldown_date'  => 'Accured Remap Cooldown Date',
+    'no_remap'                     => 'No Remap Found',
     'item_type'                    => 'Item Type',
     'client_name'                  => 'Client Name',
     'client'                       => 'Client',

--- a/src/resources/views/character/sheet.blade.php
+++ b/src/resources/views/character/sheet.blade.php
@@ -198,9 +198,9 @@
                   <dt>{{ trans('web::seat.bonus_remaps') }}</dt>
                   <dd>{{ $character->pilot_attributes->bonus_remaps ?: 0 }}</dd>
                   <dt>{{ trans('web::seat.last_remap_date') }}</dt>
-                  <dd>{{ $character->pilot_attributes->last_remap_date ?: carbon() }}</dd>
+                  <dd>{{ $character->pilot_attributes->last_remap_date ?: trans('web::seat.no_remap') }}</dd>
                   <dt>{{ trans('web::seat.accrued_remap_cooldown_date') }}</dt>
-                  <dd>{{ $character->pilot_attributes->accrued_remap_cooldown_date ?: carbon() }}</dd>
+                  <dd>{{ $character->pilot_attributes->accrued_remap_cooldown_date ?: trans('web::seat.no_remap') }}</dd>
                 </dl>
               </div>
 

--- a/src/resources/views/character/sheet.blade.php
+++ b/src/resources/views/character/sheet.blade.php
@@ -200,7 +200,7 @@
                   <dt>{{ trans('web::seat.last_remap_date') }}</dt>
                   <dd>{{ $character->pilot_attributes->last_remap_date ?: trans('web::seat.no_remap') }}</dd>
                   <dt>{{ trans('web::seat.accrued_remap_cooldown_date') }}</dt>
-                  <dd>{{ $character->pilot_attributes->accrued_remap_cooldown_date ?: trans('web::seat.no_remap') }}</dd>
+                  <dd>{{ $character->pilot_attributes->accrued_remap_cooldown_date ?: carbon() }}</dd>
                 </dl>
               </div>
 


### PR DESCRIPTION
Currently a char's remap dates are shown as today if the value is `null` this PR replaces today's date with `No Remap Found` in those cases.