### PR TITLE
fix(squads): prevent roles to be completely lost after new squad checks

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -35,6 +35,7 @@ use Seat\Services\Models\UserSetting;
 use Seat\Services\Settings\Profile;
 use Seat\Web\Models\Acl\Role;
 use Seat\Web\Models\Squads\Squad;
+use Seat\Web\Models\Squads\SquadMember;
 
 /**
  * Class User.
@@ -186,6 +187,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function squads()
     {
         return $this->belongsToMany(Squad::class, 'squad_member')
+            ->using(SquadMember::class)
             ->withPivot('created_at');
     }
 

--- a/src/Observers/AbstractSquadObserver.php
+++ b/src/Observers/AbstractSquadObserver.php
@@ -55,21 +55,21 @@ abstract class AbstractSquadObserver
 
         $member_squads = $user->squads;
 
-        // retrieve all auto squads from which the user is not already a member
+        // retrieve all auto squads from which the user is not already a member.
         $other_squads = Squad::where('type', 'auto')->whereDoesntHave('members', function ($query) use ($user) {
             $query->where('id', $user->id);
         })->get();
 
-        // add the user to those squads
-        $other_squads->each(function ($squad) use ($user) {
-            if ($squad->isEligible($user))
-                $squad->members()->save($user);
-        });
-
-        // remove the user from squads to which he's non longer eligible
+        // remove the user from squads to which he's non longer eligible.
         $member_squads->each(function ($squad) use ($user) {
             if (! $squad->isEligible($user))
                 $squad->members()->detach($user->id);
+        });
+
+        // add the user to squads from which he's not already a member.
+        $other_squads->each(function ($squad) use ($user) {
+            if ($squad->isEligible($user))
+                $squad->members()->save($user);
         });
     }
 }

--- a/src/Observers/SquadMemberObserver.php
+++ b/src/Observers/SquadMemberObserver.php
@@ -56,8 +56,14 @@ class SquadMemberObserver
         // retrieve user from pivot
         $user = User::find($member->user_id);
 
-        // retrieve roles from pivot
-        $roles = SquadRole::where('squad_id', $member->squad_id)->get();
+        // retrieve roles from pivot that need to be removed
+        $roles = SquadRole::where('squad_id', $member->squad_id)
+            ->whereNotIn('role_id', $member->squads->where('id', '<>', $member->squad_id)
+                ->map(function ($squad) {
+                    return $squad->roles->pluck('id');
+                })->flatten()
+            )
+            ->get();
 
         // remove squad roles from user
         $user->roles()->detach($roles->pluck('role_id'));


### PR DESCRIPTION
when squads are sharing same roles and the user is non longer eligible from one of them but become eligible to the other - he was only getting part squads roles.

Closes eveseat/seat#754