### PR TITLE
feat: Corp tracker

### DIFF
--- a/src/Http/Controllers/Corporation/SummaryController.php
+++ b/src/Http/Controllers/Corporation/SummaryController.php
@@ -59,8 +59,12 @@ class SummaryController extends Controller
             ->orderBy('division')
             ->get();
 
+        $trackings = $corporation->characters->reject(function ($char) {
+            return is_null($char->refresh_token);
+        })->count();
+
         return view('web::corporation.summary',
-            compact('corporation', 'sheet', 'asset_divisions', 'wallet_divisions'));
+            compact('corporation', 'sheet', 'asset_divisions', 'wallet_divisions', 'trackings'));
 
     }
 }

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -93,6 +93,7 @@ return [
     'level'                 => 'Level',
     'token'                 => 'Token',
     'token_status'          => 'Token Status',
+    'token_valid'           => 'Valid Token|Valid Tokens',
     'token_status_warning'  => 'Token has not been updated since more than a day, you should check your jobs.',
     'token_status_valid'    => 'This character has a valid registered token.',
     'token_status_invalid'  => 'You don\'t own any valid token for this character.',

--- a/src/resources/views/corporation/summary.blade.php
+++ b/src/resources/views/corporation/summary.blade.php
@@ -20,6 +20,10 @@
 
             <dt><i class="fas fa-users"></i> {{ trans('web::seat.member_capacity') }}</dt>
             <dd>{{ $sheet->member_count }} {{ trans_choice('web::seat.member', $sheet->member_count) }}</dd>
+            @can('corporation.tracking', $sheet)
+              <dt><i class="fas fa-users"></i> {{ trans('web::seat.tracking') }}</dt>
+              <dd>{{ $trackings }} / {{ $sheet->member_count }} ({{ number_format($trackings/$sheet->member_count * 100, 2) }}%) {{ trans_choice('web::seat.valid_token', $sheet->member_count) }}</dd>
+            @endcan
           </dl>
 
         </div>

--- a/src/resources/views/corporation/summary.blade.php
+++ b/src/resources/views/corporation/summary.blade.php
@@ -21,7 +21,7 @@
             <dt><i class="fas fa-users"></i> {{ trans('web::seat.member_capacity') }}</dt>
             <dd>{{ $sheet->member_count }} {{ trans_choice('web::seat.member', $sheet->member_count) }}</dd>
             @can('corporation.tracking', $sheet)
-              <dt><i class="fas fa-users"></i> {{ trans('web::seat.tracking') }}</dt>
+              <dt><i class="far fa-address-book"></i> {{ trans('web::seat.tracking') }}</dt>
               <dd>{{ $trackings }} / {{ $sheet->member_count }} ({{ number_format($trackings/$sheet->member_count * 100, 2) }}%) {{ trans_choice('web::seat.valid_token', $sheet->member_count) }}</dd>
             @endcan
           </dl>


### PR DESCRIPTION
Implement a feature showing the number of active tokens on the corporation summary page. In order to be seen the user must have the `Corporation Tracking` permission.

Closes eveseat/seat#755