### PR TITLE
fix: include ESS payout value in the bounty prize earnings

### DIFF
--- a/src/Http/Controllers/Corporation/LedgerController.php
+++ b/src/Http/Controllers/Corporation/LedgerController.php
@@ -59,7 +59,7 @@ class LedgerController extends Controller
         $month = is_null($month) ? date('m') : $month;
 
         $group_column = 'second_party_id';
-        $ref_types = ['bounty_prizes', 'bounty_prize'];
+        $ref_types = ['bounty_prizes', 'bounty_prize', 'ess_escrow_transfer'];
 
         $periods = $this->getCorporationLedgerPeriods($corporation->corporation_id, $ref_types);
         $entries = $this->getCorporationLedgerByMonth($corporation->corporation_id, $group_column, $ref_types, $year, $month);


### PR DESCRIPTION
The ESS payout should also be considered as part of the player income generated by ratting.