### PR TITLE
fix(auth): when a user account is deleted, drop definitely attached tokens

### DIFF
--- a/src/database/migrations/2021_04_05_124225_fix_issue_eveseat_web_793.php
+++ b/src/database/migrations/2021_04_05_124225_fix_issue_eveseat_web_793.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2021 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Class FixIssueEveseatWeb793.
+ */
+class FixIssueEveseatWeb793 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('refresh_tokens')
+            ->leftJoin('users', 'user_id', '=', 'id')
+            ->whereNull('id')
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
when user accounts are manually deleted, we were keeping attached tokens but soft deleting them.
as a result, if we had to recover the token or if the character was transferred - end user was not able to create a new account and get an exception due to user relation null exception.

since user deletion is an admin manual action, we assume token might be safely removed definitely.
however, we keep track of the action using security logs.

Closes eveseat/seat#793