### PR TITLE
Confirm destructive operations

### DIFF
--- a/src/resources/js/seat.js
+++ b/src/resources/js/seat.js
@@ -19,6 +19,26 @@ $(document).on("click", ".confirmform", function (e) {
     });
 });
 
+// Deletion 'confirm' dialog.
+// Make your submit button part of class confirmdelete, and viola.
+// You can add an entity name by adding a "data-seat-entity" attribute.
+var currentForm;
+$(document).on("click", ".confirmdelete", function (e) {
+    currentForm = $(this).closest("form");
+    e.preventDefault();
+    entity = $(this).data('seat-entity');
+    if (typeof entity !== 'undefined') {
+        message = `Are you sure you want to delete this ${entity}?`;
+    } else {
+        message = 'Are you sure you want to delete this?';
+    }
+    bootbox.confirm(message, function (confirmed) {
+        if (confirmed) {
+            currentForm.submit();
+        }
+    });
+});
+
 // Generic 'confirm' dialog code for links.
 // Make your link button part of class confirmlink, and viola
 $(document).on("click", "a.confirmlink", function (event) {

--- a/src/resources/views/character/partials/delete.blade.php
+++ b/src/resources/views/character/partials/delete.blade.php
@@ -2,7 +2,7 @@
   <form method="post" action="{{ route('character.destroy', ['character' => $row->character_id]) }}">
     {{ csrf_field() }}
     {{ method_field('delete') }}
-    <button class="btn btn-xs btn-danger">
+    <button class="btn btn-xs btn-danger confirmdelete" data-seat-entity="{{ trans('web::seat.character') }}">
       <i class="fas fa-trash-alt"></i>
       {{ trans('web::seat.delete') }}
     </button>

--- a/src/resources/views/configuration/access/partials/action.blade.php
+++ b/src/resources/views/configuration/access/partials/action.blade.php
@@ -8,7 +8,7 @@
       {{ trans('web::seat.edit') }}
     </a>
     @if($row->title !== 'Superuser')
-      <button type="submit" class="btn btn-danger">
+      <button type="submit" class="btn btn-danger confirmdelete" data-seat-entity="{{ trans('web::seat.role') }}">
         <i class="fas fa-trash-alt"></i>
         {{ trans('web::seat.delete') }}
       </button>

--- a/src/resources/views/configuration/users/buttons/delete.blade.php
+++ b/src/resources/views/configuration/users/buttons/delete.blade.php
@@ -6,7 +6,7 @@
   <form method="post" action="{{ route('configuration.users.delete', ['user_id' => $row->id]) }}">
     {{ csrf_field() }}
     {{ method_field('DELETE') }}
-    <button class="btn btn-sm btn-danger">
+    <button class="btn btn-sm btn-danger confirmdelete" data-seat-entity="{{ trans('web::seat.user') }}">
       <i class="fas fa-trash-alt"></i> {{ trans('web::seat.delete') }}
     </button>
   </form>

--- a/src/resources/views/corporation/partials/delete.blade.php
+++ b/src/resources/views/corporation/partials/delete.blade.php
@@ -2,7 +2,7 @@
   <form method="post" action="{{ route('corporation.destroy', ['corporation' => $row->corporation_id]) }}">
     {!! csrf_field() !!}
     {!! method_field('delete') !!}
-    <button class="btn btn-xs btn-danger">
+    <button class="btn btn-xs btn-danger confirmdelete" data-seat-entity="{{ trans('web::seat.corporation') }}">
       <i class="fas fa-trash-alt"></i>
       {{ trans('web::seat.delete') }}
     </button>

--- a/src/resources/views/squads/buttons/application/reject.blade.php
+++ b/src/resources/views/squads/buttons/application/reject.blade.php
@@ -1,4 +1,4 @@
-<button class="btn btn-sm btn-danger" form="form-reject-{{ $row->application_id }}">
+<button class="btn btn-sm btn-danger confirmform" form="form-reject-{{ $row->application_id }}">
   <i class="fas fa-times"></i> {{ trans('web::squads.reject') }}
 </button>
 <form method="post" action="{{ route('squads.applications.reject', ['squad' => request()->squad, 'id' => $row->application_id]) }}" id="form-reject-{{ $row->application_id }}">

--- a/src/resources/views/squads/buttons/roles/remove.blade.php
+++ b/src/resources/views/squads/buttons/roles/remove.blade.php
@@ -4,7 +4,7 @@
             {!! csrf_field() !!}
             {!! method_field('DELETE') !!}
             <input type="hidden" name="role_id" value="{{ $row->id }}" />
-            <button type="submit" class="btn btn-danger btn-sm">
+            <button type="submit" class="btn btn-danger btn-sm confirmform">
               <i class="fas fa-trash-alt"></i> {{ trans('web::squads.remove') }}
             </button>
         </form>

--- a/src/resources/views/squads/buttons/squads/kick.blade.php
+++ b/src/resources/views/squads/buttons/squads/kick.blade.php
@@ -4,7 +4,7 @@
       <form method="post" action="{{ route('squads.members.kick', ['squad' => request()->squad, 'member' => $row]) }}">
         {!! csrf_field() !!}
         {!! method_field('DELETE') !!}
-        <button type="submit" class="btn btn-danger btn-sm">
+        <button type="submit" class="btn btn-danger btn-sm confirmform">
           <i class="fas fa-crosshairs"></i> {{ trans('web::squads.kick') }}
         </button>
       </form>

--- a/src/resources/views/tools/moons/buttons/delete.blade.php
+++ b/src/resources/views/tools/moons/buttons/delete.blade.php
@@ -1,5 +1,5 @@
 @can('moon.manage_moon_reports')
-    <button type="submit" class="btn btn-sm btn-danger" form="moon-delete-{{ $row->moon_id }}">
+    <button type="submit" class="btn btn-sm btn-danger confirmdelete" data-seat-entity="{{ trans('web::seat.moon') }}" form="moon-delete-{{ $row->moon_id }}">
         <i class="fas fa-trash-alt"></i> {{ trans('web::seat.delete') }}
     </button>
     <form method="post" action="{{ route('tools.moons.destroy', ['report' => $row->moon_id]) }}" id="moon-delete-{{ $row->moon_id }}">


### PR DESCRIPTION
This PR adds a new `bootbox` confirmation dialog for deletion and uses the existing `confirmform` dialog so that (I hope?) all destructive operations have confirmation either in the form of `Are you sure you want to delete ${entity}` or in the form of `Are you sure you want to continue?`