### PR TITLE
Implemented filtering based on current selection

### DIFF
--- a/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
+++ b/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
@@ -54,7 +54,7 @@ class MoonRankScope implements DataTableScope
      **/
     public function apply($query) {
         $query->whereHas('content', function ($type) use ($group_id) {
-            $type->->whereIn('marketGroupID', $this->groups);
+            $type->whereIn('marketGroupID', $this->groups);
         });
 
         return $query;

--- a/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
+++ b/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
@@ -53,7 +53,7 @@ class MoonRankScope implements DataTableScope
      * @return mixed
      **/
     public function apply($query) {
-        $query->whereHas('content', function ($type) use ($group_id) {
+        $query->whereHas('content', function ($type) {
             $type->whereIn('marketGroupID', $this->groups);
         });
 

--- a/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
+++ b/src/Http/DataTables/Scopes/Filters/MoonRankScope.php
@@ -53,11 +53,9 @@ class MoonRankScope implements DataTableScope
      * @return mixed
      **/
     public function apply($query) {
-        foreach ($this->groups as $group_id) {
-            $query->whereHas('content', function ($type) use ($group_id) {
-                $type->where('marketGroupID', $group_id);
-            });
-        }
+        $query->whereHas('content', function ($type) use ($group_id) {
+            $type->->whereIn('marketGroupID', $this->groups);
+        });
 
         return $query;
     }


### PR DESCRIPTION
The current filter option worked lightly different from what users expect to see. Instead of filtering on a range of moons, it filtered only moons that has all the selected materials, instead of showing a compromised list that the user wanted.

For example, say you want to only see R16,R32 and R64 moons. With the previous setup, this was simply not possible since you would end up with a query like

->andWhere(moon is R16)->andWhere(moon is R32)->andWhere(moon is R64)

Altering the format of the query allows for all the same usecases at it previously provided, as well as support other usecases.