### PR TITLE
Fix backdrop for radar chart ticks

### DIFF
--- a/src/resources/views/character/skills.blade.php
+++ b/src/resources/views/character/skills.blade.php
@@ -114,6 +114,7 @@
           scale : {
             ticks: {
               beginAtZero: true,
+              showLabelBackdrop: false,
               max        : 100
             }
           },

--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -249,6 +249,7 @@
             scale : {
               ticks: {
                 beginAtZero: true,
+                showLabelBackdrop: false,
                 max        : 100
               }
             },


### PR DESCRIPTION
Corrects issue when using Jet skin, ticks have white backdrop enabled by default.