### PR TITLE
Mining Overhaul

### DIFF
--- a/src/Http/Controllers/Corporation/ExtractionController.php
+++ b/src/Http/Controllers/Corporation/ExtractionController.php
@@ -13,7 +13,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License `for more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
@@ -39,16 +39,15 @@ class ExtractionController extends Controller
      */
     public function getExtractions(CorporationInfo $corporation)
     {
-        // retrieve any valid extraction for the current corporation
-        $moons = UniverseMoonReport::with(
-            'content', 'moon', 'moon.solar_system', 'moon.constellation',
-                'moon.region', 'moon.extraction', 'moon.extraction.structure', 'moon.extraction.structure.info'
-            )->whereHas('moon.extraction.structure', function ($query) use ($corporation) {
-                $query->where('corporation_id', $corporation->corporation_id);
-            })->whereHas('moon.extraction', function ($query) {
-                $query->where('natural_decay_time', '>', carbon()->subSeconds(CorporationIndustryMiningExtraction::THEORETICAL_DEPLETION_COUNTDOWN));
-            })->get();
 
-        return view('web::corporation.extraction.extraction', compact('moons', 'corporation'));
+        $extractions = CorporationIndustryMiningExtraction::with(
+            'moon', 'moon.solar_system', 'moon.constellation', 'moon.region',
+            'moon.moon_report', 'moon.moon_report.content', 'structure', 'structure.info')
+            ->where('corporation_id', $corporation->corporation_id)
+            ->where('natural_decay_time', '>', carbon()->subSeconds(CorporationIndustryMiningExtraction::THEORETICAL_DEPLETION_COUNTDOWN))
+            ->get();
+        
+
+        return view('web::corporation.extraction.extraction', compact('extractions', 'corporation'));
     }
 }

--- a/src/Http/Controllers/Corporation/ExtractionController.php
+++ b/src/Http/Controllers/Corporation/ExtractionController.php
@@ -13,7 +13,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License `for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
@@ -25,16 +25,16 @@ namespace Seat\Web\Http\Controllers\Corporation;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Industry\CorporationIndustryMiningExtraction;
 use Seat\Web\Http\Controllers\Controller;
-use Seat\Web\Models\UniverseMoonReport;
 
 /**
  * Class ExtractionController.
+ *
  * @package Seat\Web\Http\Controllers\Corporation
  */
 class ExtractionController extends Controller
 {
     /**
-     * @param \Seat\Eveapi\Models\Corporation\CorporationInfo $corporation
+     * @param  \Seat\Eveapi\Models\Corporation\CorporationInfo  $corporation
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function getExtractions(CorporationInfo $corporation)
@@ -46,7 +46,6 @@ class ExtractionController extends Controller
             ->where('corporation_id', $corporation->corporation_id)
             ->where('natural_decay_time', '>', carbon()->subSeconds(CorporationIndustryMiningExtraction::THEORETICAL_DEPLETION_COUNTDOWN))
             ->get();
-        
 
         return view('web::corporation.extraction.extraction', compact('extractions', 'corporation'));
     }

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -638,8 +638,11 @@ return [
     'faction'                      => 'Faction',
 
     'start_at'                     => 'Start at',
+    'drill_start'                  => 'Drill Start',
     'chunk_arrival'                => 'Chunk Arrival',
+    'chunk_age'                    => 'Extraction Length',
     'self_destruct'                => 'Self-Destruct',
+    'auto_fracture'                => 'Auto Fracture',
     'rarity'                       => 'Rarity',
     'rate'                         => 'Rate',
 

--- a/src/resources/views/corporation/extraction/extraction.blade.php
+++ b/src/resources/views/corporation/extraction/extraction.blade.php
@@ -8,16 +8,16 @@
 <div class="btn-toolbar">
   @can('moon.manage_moon_reports')
   <div class="btn-group pr-3">
-      <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-success float-right" aria-label="Settings">
-        <i class="fas fa-plus-square pr-1"></i>Add Missing Moon Scan
+      <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-success float-right" aria-label="Settings" title="Add a moon scan, used to populate ore information">
+        <i class="fas fa-plus-square pr-1"></i>Add Scan
       </button>
   </div>
   @endcan
 
 
   <div class="btn-group">
-    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".rate-collapse" >
-      <i class="fas fa-eye pr-1"></i>Toggle Ore Rate
+    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".rate-collapse" title="Show/Hide the Moon Ore and Volume">
+      <i class="fas fa-eye pr-1"></i>Toggle Ore
     </button>
   </div>
 </div>

--- a/src/resources/views/corporation/extraction/extraction.blade.php
+++ b/src/resources/views/corporation/extraction/extraction.blade.php
@@ -6,19 +6,20 @@
 
 <p class="container-fluid">
 <div class="btn-toolbar">
-  <div class="btn-group">
-    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".rate-collapse" >Toggle Ore Rate</button>
-  </div>
-
   @can('moon.manage_moon_reports')
-  <div class="btn-group pl-3">
-
-      <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-primary float-right" aria-label="Settings">
-        <i class="fas fa-cogs"></i> Add Missing Moon Scan
+  <div class="btn-group pr-3">
+      <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-success float-right" aria-label="Settings">
+        <i class="fas fa-plus-square pr-1"></i>Add Missing Moon Scan
       </button>
-
   </div>
   @endcan
+
+
+  <div class="btn-group">
+    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".rate-collapse" >
+      <i class="fas fa-eye pr-1"></i>Toggle Ore Rate
+    </button>
+  </div>
 </div>
 </p>
 

--- a/src/resources/views/corporation/extraction/extraction.blade.php
+++ b/src/resources/views/corporation/extraction/extraction.blade.php
@@ -3,7 +3,26 @@
 @section('page_header', trans_choice('web::seat.corporation', 1) . ' ' . trans_choice('web::seat.extraction', 0))
 
 @section('corporation_content')
-@foreach ($moons->sortBy('moon.extraction.chunk_arrival_time')->chunk(3) as $row)
+
+<p class="container-fluid">
+<div class="btn-toolbar">
+  <div class="btn-group">
+    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".rate-collapse" >Toggle Ore Rate</button>
+  </div>
+
+  @can('moon.manage_moon_reports')
+  <div class="btn-group pl-3">
+
+      <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-primary float-right" aria-label="Settings">
+        <i class="fas fa-cogs"></i> Add Missing Moon Scan
+      </button>
+
+  </div>
+  @endcan
+</div>
+</p>
+
+@foreach ($extractions->sortBy('chunk_arrival_time')->chunk(3) as $row)
   <div class="row">
   @foreach($row as $column)
     @include('web::corporation.extraction.partials.card')

--- a/src/resources/views/corporation/extraction/partials/card-body.blade.php
+++ b/src/resources/views/corporation/extraction/partials/card-body.blade.php
@@ -1,12 +1,26 @@
+@if (! is_null($column->structure) && ! is_null($column->structure->info))
 <h5>
-  <i class="fa fa-map"></i>
+<i class="fas fa-monument"></i>
+{{ $column->structure->info->name }}
+</h5>
+<h6>
+<i class="fa fa-map"></i>
   @if (! is_null($column->moon) && ! is_null($column->moon->region))
     {{ $column->moon->region->name }}
-    @if (! is_null($column->moon->constellation))
-      | {{ $column->moon->constellation->name }}
-    @else
-      {{ sprintf('%s %s', trans('web::seat.unknown'), trans('web::seat.constellation')) }}
-    @endif
+  @else
+    {{ sprintf('%s %s', trans('web::seat.unknown'), trans('web::seat.region')) }}
+  @endif
+</h6>
+
+@else
+<h5>
+<i class="fas fa-monument"></i>
+{{ sprintf('%s %s', trans('web::seat.unknown'), trans_choice('web::seat.structure', 1)) }}
+</h5>
+<h6>
+<i class="fa fa-map"></i>
+  @if (! is_null($column->moon) && ! is_null($column->moon->region))
+    {{ $column->moon->region->name }}
     @if (! is_null($column->moon->solar_system))
       | {{ $column->moon->solar_system->name }}
     @else
@@ -15,7 +29,10 @@
   @else
     {{ sprintf('%s %s', trans('web::seat.unknown'), trans('web::seat.region')) }}
   @endif
-</h5>
+</h6>
+@endif
+
+
 <div class="text-muted">
   <i class="fas fa-globe"></i>
   @if (! is_null($column->moon))
@@ -24,58 +41,72 @@
     {{ trans('web::seat.unknown') }}
   @endif
 </div>
-<div class="text-muted">
-    <i class="fas fa-monument"></i> {{ $column->moon->extraction->structure->info->name }}
-</div>
+
+
 <hr/>
-<dl class="dl-horizontal">
-  <dt>{{ trans('web::seat.start_at') }}</dt>
-  <dd>{{ $column->moon->extraction->extraction_start_time }}</dd>
-  <dt>{{ trans('web::seat.chunk_arrival') }}</dt>
-  <dd>{{ $column->moon->extraction->chunk_arrival_time }}</dd>
-  <dt>{{ trans('web::seat.self_destruct') }}</dt>
-  <dd>{{ $column->moon->extraction->natural_decay_time }}</dd>
+
+<dl class="row">
+  <dt class="col-lg-5">{{ trans('web::seat.drill_start') }}</dt>
+  <dd class="col-lg-7">{{ substr($column->extraction_start_time, 0, -3) }}</dd>
+  <dt class="col-lg-5">{{ trans('web::seat.chunk_arrival') }}</dt>
+  <dd class="col-lg-7">{{ substr($column->chunk_arrival_time, 0, -3) }}</dd>
+  <dt class="col-lg-5">{{ trans('web::seat.auto_fracture') }}</dt>
+  <dd class="col-lg-7">{{ substr($column->natural_decay_time, 0, -3) }}</dd>
 </dl>
-@if (! $column->content->isEmpty())
-<hr/>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>{{ trans_choice('web::seat.type', 1) }}</th>
-      <th>{{ trans('web::seat.rate') }}</th>
-      <th>{{ trans('web::seat.rarity') }}</th>
-    </tr>
-  </thead>
-  <tbody>
-    @foreach($column->content as $type)
+
+@if (! is_null($column->moon)  && ! is_null($column->moon->moon_report) && ! $column->moon->moon_report->content->isEmpty())
+<div class="collapse rate-collapse">
+  <table class="table table-striped">
+    <thead>
       <tr>
-        <td>
-          @include('web::partials.type', ['type_id' => $type->typeID, 'type_name' => $type->typeName])
-        </td>
-        <td>{{ number_format($type->pivot->rate * 100) }} %</td>
-        <td>
-          @switch($type->marketGroupID)
-            @case(2396)
-              <span class="badge badge-success">R4</span>
-              @break
-            @case(2397)
-              <span class="badge badge-primary">R8</span>
-              @break
-            @case(2398)
-              <span class="badge badge-info">R16</span>
-              @break
-            @case(2400)
-              <span class="badge badge-warning">R32</span>
-              @break
-            @case(2401)
-              <span class="badge badge-danger">R64</span>
-              @break
-            @default
-              <span class="badge badge-default">ORE</span>
-          @endswitch
-        </td>
+        <th>{{ trans_choice('web::seat.type', 1) }}</th>
+        <th>{{ trans('web::seat.volume') }}</th>
+        <th>{{ trans('web::seat.rarity') }}</th>
       </tr>
-    @endforeach
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      @foreach($column->moon->moon_report->content as $type)
+        <tr>
+          <td>
+            @include('web::partials.type', ['type_id' => $type->typeID, 'type_name' => $type->typeName])
+          </td>
+          <td>{{ number_format($type->pivot->rate * $column->volume()) }} m3</td>
+          <td>
+            @switch($type->marketGroupID)
+              @case(2396)
+                <span class="badge badge-success">R4</span>
+                @break
+              @case(2397)
+                <span class="badge badge-primary">R8</span>
+                @break
+              @case(2398)
+                <span class="badge badge-info">R16</span>
+                @break
+              @case(2400)
+                <span class="badge badge-warning">R32</span>
+                @break
+              @case(2401)
+                <span class="badge badge-danger">R64</span>
+                @break
+              @default
+                <span class="badge badge-default">ORE</span>
+            @endswitch
+          </td>
+        </tr>
+      @endforeach
+      @for($i = 0; $i < (4 - $column->moon->moon_report->content->count()); $i++)
+      <tr>
+        <td>-</td>
+        <td>-</td>
+        <td>-</td>
+      </tr>
+      @endfor
+      <tr>
+        <td>Total</td>
+        <td>{{ number_format($column->moon->moon_report->content->sum('pivot.rate') * $column->volume()) }} m3</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 @endif

--- a/src/resources/views/corporation/extraction/partials/card-body.blade.php
+++ b/src/resources/views/corporation/extraction/partials/card-body.blade.php
@@ -101,11 +101,11 @@
         <td>-</td>
       </tr>
       @endfor
-      <tr>
-        <td>Total</td>
-        <td>{{ number_format($column->moon->moon_report->content->sum('pivot.rate') * $column->volume()) }} m3</td>
-        <td></td>
-      </tr>
+      <tfoot>
+        <th>Total</th>
+        <th>{{ number_format($column->moon->moon_report->content->sum('pivot.rate') * $column->volume()) }} m3</th>
+        <th></th>
+      </tfoot>
     </tbody>
   </table>
 </div>

--- a/src/resources/views/corporation/extraction/partials/card.blade.php
+++ b/src/resources/views/corporation/extraction/partials/card.blade.php
@@ -1,41 +1,27 @@
 <div class="col-md-4">
-  <div class="info-box @if($column->moon->extraction->isReady()) bg-gradient-success @else bg-gradient-info @endif">
+  <div class="info-box @if($column->isReady()) bg-gradient-success @else bg-gradient-info @endif">
     <span class="info-box-icon">
-      <i class="@if($column->moon->extraction->isReady()) fas fa-recycle @else far fa-gem @endif"></i>
+      <i class="@if($column->isReady()) far fa-gem @else far fa-hourglass @endif"></i>
     </span>
     <div class="info-box-content">
-      <span class="info-box-text">
-        @if(! is_null($column->moon->extraction->structure))
-        {{ $column->moon->extraction->structure->name }}
-        @else
-        {{ sprintf('%s %s', trans('web::seat.unknown'), trans_choice('web::seat.structure', 1)) }}
-        @endif
-      </span>
       <span class="info-box-number">
-        @if($column->moon->extraction->isReady()) Active @else {{ human_diff($column->moon->extraction->chunk_arrival_time) }} @endif
+        @if($column->isReady()) Active @else {{ human_diff($column->chunk_arrival_time) }} @endif
       </span>
-      @if($column->moon->extraction->isReady())
+      @if($column->isReady())
       <div class="progress">
-        <div class="progress-bar" style="width: {{ round(carbon($column->moon->extraction->chunk_arrival_time)->diffInSeconds(carbon()) / $column->moon->extraction::THEORETICAL_DEPLETION_COUNTDOWN * 100, 0) }}%"></div>
+        <div class="progress-bar" style="width: {{ round(carbon($column->chunk_arrival_time)->diffInSeconds(carbon()) / $column::THEORETICAL_DEPLETION_COUNTDOWN * 100, 0) }}%"></div>
       </div>
       @else
       <div class="progress">
-        <div class="progress-bar" style="width: {{ round(carbon($column->moon->extraction->extraction_start_time)->diffInSeconds(carbon()) / carbon($column->moon->extraction->chunk_arrival_time)->diffInSeconds($column->moon->extraction->extraction_start_time) * 100, 0) }}%"></div>
+        <div class="progress-bar" style="width: {{ round(carbon($column->extraction_start_time)->diffInSeconds(carbon()) / carbon($column->chunk_arrival_time)->diffInSeconds($column->extraction_start_time) * 100, 0) }}%"></div>
       </div>
       @endif
-      <span class="progress-description">Chunk age: {{number_format(carbon($column->moon->extraction->chunk_arrival_time)->diffInDays($column->moon->extraction->extraction_start_time), 0)}} days</span>
+      <span class="progress-description">{{ trans('web::seat.chunk_age') }}: {{number_format(carbon($column->chunk_arrival_time)->diffInDays($column->extraction_start_time), 0)}} days</span>
     </div>
   </div>
   <div class="card">
     <div class="card-body">
       @include('web::corporation.extraction.partials.card-body')
     </div>
-    @can('moon.manage_moon_reports')
-      <div class="card-footer">
-        <button type="button" data-toggle="modal" data-target="#moon-import" class="btn btn-sm btn-link float-right" aria-label="Settings">
-          <i class="fas fa-cogs"></i> Settings
-        </button>
-      </div>
-    @endcan
   </div>
 </div>

--- a/src/resources/views/tools/moons/modals/components/components.blade.php
+++ b/src/resources/views/tools/moons/modals/components/components.blade.php
@@ -22,7 +22,55 @@
               .done(function (data) {
                   body.html(data);
 
-                  $('table.datatable').DataTable();
+                  $('#rawMaterials').DataTable({
+                    "footerCallback": function( row, data, start, end, display) {
+                      var api = this.api(), data;
+                      // converting to interger to find total
+                      var intVal = function ( i ) {
+                          return typeof i === 'string' ?
+                              i.replace(/[\$,]/g, '')*1 :
+                              typeof i === 'number' ?
+                                  i : 0;
+                      };
+
+                      total = api
+                        .column(4)
+                        .data()
+                        .reduce( function (a, b){
+                          return intVal(a) + intVal(b)
+                        }, 0);
+
+                      $(api.column(4).footer() ).html(
+                        (total).toLocaleString(undefined, {minimumFractionDigits: 2})
+                      );
+                    }
+                  });
+
+                  $('#refinedMaterials').DataTable({
+                    "footerCallback": function( row, data, start, end, display) {
+                      var api = this.api(), data;
+                      // converting to interger to find total
+                      var intVal = function ( i ) {
+                          return typeof i === 'string' ?
+                              i.replace(/[\$,]/g, '')*1 :
+                              typeof i === 'number' ?
+                                  i : 0;
+                      };
+
+                      total = api
+                        .column(3)
+                        .data()
+                        .reduce( function (a, b){
+                          return intVal(a) + intVal(b)
+                        }, 0);
+
+                      $(api.column(3).footer() ).html(
+                        (total).toLocaleString(undefined, {minimumFractionDigits: 2})
+                      );
+                    }
+                  });
+
+                  $('#reactionsCandidates').DataTable();
               });
       });
   </script>

--- a/src/resources/views/tools/moons/modals/components/content.blade.php
+++ b/src/resources/views/tools/moons/modals/components/content.blade.php
@@ -3,7 +3,7 @@
 
 <h4>Raw Materials</h4>
 
-<table class="table datatable table-striped">
+<table class="table datatable table-striped" id="rawMaterials">
   <thead>
     <tr>
       <th>Type</th>
@@ -26,12 +26,19 @@
         <td>{{ number_format((($type->pivot->rate * 20000 * 720) / $type->volume) * $type->price->average, 2) }}</td>
       </tr>
     @endforeach
+      <tfoot>
+        <th></th>
+        <th></th>
+        <th></th>
+        <th></th>
+        <th></th>
+      </tfoot>
   </tbody>
 </table>
 
 <h4>Refined Materials</h4>
 
-<table class="table datatable table-striped">
+<table class="table datatable table-striped" id="refinedMaterials">
   <thead>
     <tr>
       <th>Type</th>
@@ -60,12 +67,18 @@
         <td>{{ number_format($material->sum('pivot.quantity') * $material->first()->price->average) }}</td>
       </tr>
     @endforeach
+      <tfoot>
+        <th></th>
+        <th></th>
+        <th></th>
+        <th></th>
+      </tfoot>
   </tbody>
 </table>
 
 <h4>Reactions Candidates</h4>
 
-<table class="table datatable table-striped">
+<table class="table datatable table-striped" id="reactionsCandidates">
   <thead>
     <tr>
       <th>Type</th>


### PR DESCRIPTION
This PR is focused on feedback given regarding some of the mining pages within SeAT. Changes listed below.

**Extractions**

- Multiple extractions for each structure are now able to be shown. This is important so that the active extraction is not overwritten when the moon drill is immediately restarted.
- Compact Nature - The default view for the extractions page now only shows the state of the pull, the location and the times. There is a toggle button at the top of the page which will expand the panel to also show the ores on the moon where present. 
- Moon Rate - The moon rate / percentage on this page has been replaced with the volume of ore expected for the extraction. Further to this there is a also a field for the total volume expected from the extraction.
- Icons - The icons have been swapped to be more clear on the meaning. The active chunk now gets the gem icon, while the pending chunks now get an hourglass.
- Clutter - Where the structure is known, the location field now only displays the region name. Constellation names can be confusing s they look similar to system names, and the system name is present in the structure name. Where the structure is not known then the location will show the region name and the system name.
- Language - changed some of the wording to be more clear to non-technical or EASL players

**Moons Reporter**

- Added total rows to the ISK columns on the details modal.

This PR is dependant on eveseat/eveapi#313