### PR TITLE
fix: prevent update of datatables package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "lasserafn/php-initial-avatar-generator": "^4.0",
     "socialiteproviders/manager": "^3.0",
     "twbs/bootstrap": "^4.3",
-    "yajra/laravel-datatables-oracle": "^9.10",
+    "yajra/laravel-datatables-oracle": "^9.10 <9.21",
     "yajra/laravel-datatables-buttons": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
Later versions of yajra datatables have a 'fix' for sorting and pagination. This breaks a number of SeAT tables including assets. This change will pin datatables at a workable version until the cause can be identified and corrected.