### PR TITLE
allow null in character and corporation partials

### DIFF
--- a/src/resources/views/partials/character.blade.php
+++ b/src/resources/views/partials/character.blade.php
@@ -1,4 +1,7 @@
-@if ($character->name && $character->name !== trans('web::seat.unknown'))
+@if($character === null)
+  {!! img('characters', 'portrait', null, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+  <span>{{ trans('web::seat.unknown') }}</span>
+@elseif ($character->name && $character->name !== trans('web::seat.unknown'))
   @if(\Seat\Eveapi\Models\Character\CharacterInfo::find($character->character_id ?? $character->entity_id))
     <a href="{{ route('character.view.default', ['character' => $character->character_id ?? $character->entity_id]) }}">
       {!! img('characters', 'portrait', $character->character_id ?? $character->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}

--- a/src/resources/views/partials/corporation.blade.php
+++ b/src/resources/views/partials/corporation.blade.php
@@ -1,4 +1,7 @@
-@if ($corporation->name && $corporation->name !== trans('web::seat.unknown'))
+@if($corporation===null)
+  {!! img('corporations', 'logo', null, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}
+  <span>{{ trans('web::seat.unknown') }}</span>
+@elseif ($corporation->name && $corporation->name !== trans('web::seat.unknown'))
   @if(\Seat\Eveapi\Models\Corporation\CorporationInfo::find($corporation->corporation_id ?? $corporation->entity_id))
   <a href="{{ route('corporation.view.default', ['corporation' => $corporation->corporation_id ?? $corporation->entity_id]) }}">
     {!! img('corporations', 'logo', $corporation->corporation_id ?? $corporation->entity_id, 32, ['class' => 'img-circle eve-icon small-icon'], false) !!}


### PR DESCRIPTION
Allows you to enter null into the character and corporation partials. My use case is writing something like this:
```
@include("web::partials.character",["character"=>$order->user->main_character ?? null])
```
This pr is intended to be deployed together with [https://github.com/eveseat/services/pull/157](https://github.com/eveseat/services/pull/157), but it will work even if the other pr is not merged, because we have null to int conversion in the `img()` function.