### PR TITLE
bump datatables version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "lasserafn/php-initial-avatar-generator": "^4.2",
     "socialiteproviders/manager": "^4.0",
     "twbs/bootstrap": "^4.3",
-    "yajra/laravel-datatables-oracle": "^10.0",
+    "yajra/laravel-datatables-oracle": "^10.4.0",
     "yajra/laravel-datatables-buttons": "^10.0",
     "zircote/swagger-php": "^4.0"
   },


### PR DESCRIPTION
https://github.com/yajra/laravel-datatables had an[ issue](https://github.com/yajra/laravel-datatables/issues/2976) where some columns weren't rendered correctly. The issue is fixed in version 10.4, so we should start to use that version or newer