### PR TITLE
Show alt characters in character summary when token has expired

### DIFF
--- a/src/resources/views/character/includes/summary.blade.php
+++ b/src/resources/views/character/includes/summary.blade.php
@@ -27,9 +27,9 @@
     </p>
 
     <ul class="list-group list-group-unbordered mb-3">
-      @if(! is_null($character->refresh_token))
+      @if($character->refresh_token()->withTrashed()->exists())
         @can('global.invalid_tokens')
-          @foreach($character->refresh_token->user->all_characters()->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
+          @foreach($character->refresh_token()->withTrashed()->first()->user->all_characters()->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
 
           <li class="list-group-item">
 
@@ -55,7 +55,7 @@
 
           @endforeach
         @else
-          @foreach($character->refresh_token->user->characters->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
+          @foreach($character->refresh_token()->withTrashed()->first()->user->characters->where('character_id', '<>', $character->character_id)->sortBy('name') as $character_info)
 
           <li class="list-group-item">
 


### PR DESCRIPTION
fixes https://github.com/eveseat/seat/issues/856

It is currently broken since character with expired tokens have their `refresh_token` soft-deleted. This means currently SeAT can't find the user from a character with expired token since `refresh_tokens` links characters to a user. The fix is to also consider deleted tokens when searching the user from a character.

The `global.invalid_tokens` permission is respected since it only affects `user->alts` and not the first part of the chain, `character->user`

