### PR TITLE
Rewrite Filterable trait used for Squad filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env.php
 .env
 .idea/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@
 .env.php
 .env
 .idea/
+
+# testing
 vendor/
+composer.lock
+.phpunit.cache/test-results

--- a/src/Exceptions/InvalidFilterException.php
+++ b/src/Exceptions/InvalidFilterException.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Web\Exceptions;
 
 class InvalidFilterException extends \Exception

--- a/src/Exceptions/InvalidFilterException.php
+++ b/src/Exceptions/InvalidFilterException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Seat\Web\Exceptions;
+
+class InvalidFilterException extends \Exception
+{
+
+}

--- a/src/Models/Filterable.php
+++ b/src/Models/Filterable.php
@@ -51,9 +51,10 @@ trait Filterable
      */
     final public function isEligible(Model $member): bool
     {
-        // in case no filters exists, bypass check and return not eligible
+        // in case no filters exists, everyone should be allowed
+        // this is the case with manual squads
         if (! property_exists($this->getFilters(), 'and') && ! property_exists($this->getFilters(), 'or'))
-            throw new InvalidFilterException('root filter configuration is not a rule group');
+            return true;
 
         $query = new QueryGroupBuilder($member->newQuery(), true);
 

--- a/src/Models/Filterable.php
+++ b/src/Models/Filterable.php
@@ -52,8 +52,10 @@ trait Filterable
 
         // make sure we only allow results of the entity we are checking
         $query->where($member->getKeyName(),$member->getKey());
-
-        $this->applyGroup($query, $this->getFilters());
+        // wrap this in an inner query to ensure we have the correct entity and the filter applies
+        $query->where(function ($inner_query){
+            $this->applyGroup($inner_query, $this->getFilters());
+        });
 
         //return dd($query->toRawSql(), $query->exists());
         return $query->exists();

--- a/src/Models/Filterable.php
+++ b/src/Models/Filterable.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Seat\Web\Exceptions\InvalidFilterException;
 use stdClass;
 
 /**
@@ -34,65 +35,88 @@ use stdClass;
 trait Filterable
 {
     /**
+     * The filters to use.
      * @return \stdClass
      */
     abstract public function getFilters(): stdClass;
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Model  $member
-     * @return bool
+     * Check if an entity is eligible
+     * @param Model $member The entity to check
+     * @return bool Whether the entity is eligible
+     * @throws InvalidFilterException If a invalid filter configuration is used
      */
     final public function isEligible(Model $member): bool
     {
         // in case no filters exists, bypass check and return not eligible
         if (!property_exists($this->getFilters(), 'and') && !property_exists($this->getFilters(), 'or'))
-            return false;
+            throw new InvalidFilterException('root filter configuration is not a rule group');
 
-        $query = $member->newQuery();
+        $query = new QueryGroupBuilder($member->newQuery(), true);
 
-        // make sure we only allow results of the entity we are checking
-        $query->where($member->getKeyName(),$member->getKey());
-        // wrap this in an inner query to ensure we have the correct entity and the filter applies
+        // make sure we only allow results of the entity we are checking count
+        $query->where(function (Builder $inner_query) use ($member) {
+            $inner_query->where($member->getKeyName(),$member->getKey());
+        });
+
+        // wrap this in an inner query to ensure it is '(correct_entity_check) AND (rule1 AND/OR rule2)'
         $query->where(function ($inner_query){
             $this->applyGroup($inner_query, $this->getFilters());
         });
 
-        //return dd($query->toRawSql(), $query->exists());
-        return $query->exists();
+        return $query->getUnderlyingQuery()->exists();
     }
 
-    private function applyGroup(Builder $query, object $group): void
+    /**
+     * Applies a filter group to $query
+     * @param Builder $query the query to add the filter group to
+     * @param stdClass $group the filter group configuration
+     * @throws InvalidFilterException
+     */
+    private function applyGroup(Builder $query, stdClass $group): void
     {
         $query_group = new QueryGroupBuilder($query, property_exists($group, 'and'));
 
         $rules = $query_group->isAndGroup() ? $group->and : $group->or;
 
         foreach ($rules as $rule){
+            // check if this is a nested group or not
             if(property_exists($rule,'path')){
                 $this->applyRule($query_group, $rule);
             } else {
                 // this is a nested group
-                $query->where(function ($group_query) use ($group) {
-                    $this->applyGroup($group_query, $group);
+                $query->where(function ($group_query) use ($rule) {
+                    $this->applyGroup($group_query, $rule);
                 });
             }
         }
     }
 
-    private function applyRule(QueryGroupBuilder $query, object $rule): void {
+    /**
+     * Applies a rule to a query group
+     * @param QueryGroupBuilder $query the query to add the rule to
+     * @param  stdClass $rule the rule configuration
+     * @throws InvalidFilterException
+     */
+    private function applyRule(QueryGroupBuilder $query, stdClass $rule): void {
         // 'is' operator
-        if($rule->operator === '='){
-            $query->whereHas($rule->path, function ($inner_query) use ($rule) {
+        if($rule->operator === '=' || $rule->operator === '<' || $rule->operator==='>'){
+            // normal comparison operations need to relation to exist
+            $query->whereHas($rule->path, function (Builder $inner_query) use ($rule) {
                 $inner_query->where($rule->field,$rule->operator, $rule->criteria);
             });
-        } else if ($rule->operator === '<>') {
-            $query->where(function (Builder $inner_query) use ($rule) {
-               $inner_query->whereDoesntHave($rule->path, function ($final_query) use ($rule) {
-                   $final_query->where($rule->field, $rule->criteria);
-               });
+        } else if ($rule->operator === '<>' || $rule->operator === '!=') {
+            // not equal is special cased since a missing relation is the same as not equal
+            $query->whereDoesntHave($rule->path, function (Builder $inner_query) use ($rule) {
+                $inner_query->where($rule->field, $rule->criteria);
+            });
+        } else if($rule->operator === 'contains'){
+            // contains is maybe a misleading name, since it actually checks if json contains a value
+            $query->whereHas($rule->path, function (Builder $inner_query) use ($rule) {
+                $inner_query->whereJsonContains($rule->field,$rule->criteria);
             });
         } else {
-            throw new \Exception('not implemented');
+            throw new InvalidFilterException(sprintf('Unknown rule operator: \'%s\'',$rule->operator));
         }
     }
 }

--- a/src/Models/Filterable.php
+++ b/src/Models/Filterable.php
@@ -85,7 +85,7 @@ trait Filterable
                 $this->applyRule($query_group, $rule);
             } else {
                 // this is a nested group
-                $query->where(function ($group_query) use ($rule) {
+                $query_group->where(function ($group_query) use ($rule) {
                     $this->applyGroup($group_query, $rule);
                 });
             }

--- a/src/Models/Filterable.php
+++ b/src/Models/Filterable.php
@@ -85,6 +85,12 @@ trait Filterable
             $query->whereHas($rule->path, function ($inner_query) use ($rule) {
                 $inner_query->where($rule->field,$rule->operator, $rule->criteria);
             });
+        } else if ($rule->operator === '<>') {
+            $query->where(function (Builder $inner_query) use ($rule) {
+               $inner_query->whereDoesntHave($rule->path, function ($final_query) use ($rule) {
+                   $final_query->where($rule->field, $rule->criteria);
+               });
+            });
         } else {
             throw new \Exception('not implemented');
         }

--- a/src/Models/QueryGroupBuilder.php
+++ b/src/Models/QueryGroupBuilder.php
@@ -1,11 +1,32 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Web\Models;
+
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Helper to build query where clauses that are either connected by AND or by OR
+ * Helper to build query where clauses that are either connected by AND or by OR.
  */
 class QueryGroupBuilder
 {
@@ -20,10 +41,10 @@ class QueryGroupBuilder
     protected Builder $query;
 
     /**
-     * @param Builder $query The query builder to add the where clauses to
-     * @param bool $is_and_group Whether the where clauses should be linked by AND
+     * @param  Builder  $query  The query builder to add the where clauses to
+     * @param  bool  $is_and_group  Whether the where clauses should be linked by AND
      */
-    public function __construct(Builder $query, bool $is_and_group){
+    public function __construct(Builder $query, bool $is_and_group) {
         $this->query = $query;
         $this->is_and_group = $is_and_group;
     }
@@ -44,9 +65,11 @@ class QueryGroupBuilder
     }
 
     /**
-     * Either adds a 'where' or 'orWhere' to the query, depending on if it is an AND linked group or not
-     * @param Closure $callback a callback to add constraints
+     * Either adds a 'where' or 'orWhere' to the query, depending on if it is an AND linked group or not.
+     *
+     * @param  Closure  $callback  a callback to add constraints
      * @return $this
+     *
      * @see Builder::where
      * @see Builder::orWhere
      */
@@ -56,14 +79,17 @@ class QueryGroupBuilder
         } else {
            $this->query->orWhere($callback);
         }
+
         return $this;
     }
 
     /**
-     * Either adds a 'whereHas' or 'orWhereHas' to the query, depending on if it is an AND linked group or not
-     * @param string $relation the relation to check for existence
-     * @param Closure $callback a callback to add more constraints
+     * Either adds a 'whereHas' or 'orWhereHas' to the query, depending on if it is an AND linked group or not.
+     *
+     * @param  string  $relation  the relation to check for existence
+     * @param  Closure  $callback  a callback to add more constraints
      * @return $this
+     *
      * @see Builder::whereHas
      * @see Builder::orWhereHas
      */
@@ -73,14 +99,17 @@ class QueryGroupBuilder
         } else {
             $this->query->orWhereHas($relation, $callback);
         }
+
         return $this;
     }
 
     /**
-     * Either adds a 'whereDoesntHave' or 'orWhereDoesntHave' to the query, depending on if it is an AND linked group or not
-     * @param string $relation the relation to check for absence
-     * @param Closure $callback a callback to add more constraints
+     * Either adds a 'whereDoesntHave' or 'orWhereDoesntHave' to the query, depending on if it is an AND linked group or not.
+     *
+     * @param  string  $relation  the relation to check for absence
+     * @param  Closure  $callback  a callback to add more constraints
      * @return $this
+     *
      * @see Builder::whereDoesntHave
      * @see Builder::orWhereDoesntHave
      */
@@ -90,6 +119,7 @@ class QueryGroupBuilder
         } else {
             $this->query->orWhereDoesntHave($relation, $callback);
         }
+
         return $this;
     }
 }

--- a/src/Models/QueryGroupBuilder.php
+++ b/src/Models/QueryGroupBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Seat\Web\Models;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+
+class QueryGroupBuilder
+{
+    protected bool $is_and_group;
+    protected Builder $query;
+
+    public function __construct(Builder $query, bool $is_and_group){
+        $this->query = $query;
+        $this->is_and_group = $is_and_group;
+    }
+
+    public function isAndGroup(): bool {
+        return $this->is_and_group;
+    }
+
+    public function where(Closure $callback): QueryGroupBuilder {
+        if($this->is_and_group){
+            $this->query->where($callback);
+        } else {
+           $this->query->orWhere($callback);
+        }
+        return $this;
+    }
+
+    public function whereHas(string $relation, Closure $callback): QueryGroupBuilder {
+        if($this->is_and_group){
+            $this->query->whereHas($relation, $callback);
+        } else {
+            $this->query->orWhereHas($relation, $callback);
+        }
+        return $this;
+    }
+}

--- a/src/Models/QueryGroupBuilder.php
+++ b/src/Models/QueryGroupBuilder.php
@@ -4,20 +4,52 @@ namespace Seat\Web\Models;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * Helper to build query where clauses that are either connected by AND or by OR
+ */
 class QueryGroupBuilder
 {
+    /**
+     * @var bool Whether the where clauses should be linked by AND
+     */
     protected bool $is_and_group;
+
+    /**
+     * @var Builder The query builder to add the where clauses to
+     */
     protected Builder $query;
 
+    /**
+     * @param Builder $query The query builder to add the where clauses to
+     * @param bool $is_and_group Whether the where clauses should be linked by AND
+     */
     public function __construct(Builder $query, bool $is_and_group){
         $this->query = $query;
         $this->is_and_group = $is_and_group;
     }
 
+    /**
+     * @return bool Returns true when the where clauses are linked by AND
+     */
     public function isAndGroup(): bool {
         return $this->is_and_group;
     }
 
+    /**
+     * @return Builder The underlying query builder used for this group
+     */
+    public function getUnderlyingQuery(): Builder
+    {
+        return $this->query;
+    }
+
+    /**
+     * Either adds a 'where' or 'orWhere' to the query, depending on if it is an AND linked group or not
+     * @param Closure $callback a callback to add constraints
+     * @return $this
+     * @see Builder::where
+     * @see Builder::orWhere
+     */
     public function where(Closure $callback): QueryGroupBuilder {
         if($this->is_and_group){
             $this->query->where($callback);
@@ -27,11 +59,36 @@ class QueryGroupBuilder
         return $this;
     }
 
+    /**
+     * Either adds a 'whereHas' or 'orWhereHas' to the query, depending on if it is an AND linked group or not
+     * @param string $relation the relation to check for existence
+     * @param Closure $callback a callback to add more constraints
+     * @return $this
+     * @see Builder::whereHas
+     * @see Builder::orWhereHas
+     */
     public function whereHas(string $relation, Closure $callback): QueryGroupBuilder {
         if($this->is_and_group){
             $this->query->whereHas($relation, $callback);
         } else {
             $this->query->orWhereHas($relation, $callback);
+        }
+        return $this;
+    }
+
+    /**
+     * Either adds a 'whereDoesntHave' or 'orWhereDoesntHave' to the query, depending on if it is an AND linked group or not
+     * @param string $relation the relation to check for absence
+     * @param Closure $callback a callback to add more constraints
+     * @return $this
+     * @see Builder::whereDoesntHave
+     * @see Builder::orWhereDoesntHave
+     */
+    public function whereDoesntHave(string $relation, Closure $callback): QueryGroupBuilder {
+        if($this->is_and_group){
+            $this->query->whereDoesntHave($relation, $callback);
+        } else {
+            $this->query->orWhereDoesntHave($relation, $callback);
         }
         return $this;
     }

--- a/tests/Squads/AllianceRuleTest.php
+++ b/tests/Squads/AllianceRuleTest.php
@@ -155,4 +155,44 @@ class AllianceRuleTest extends TestCase
                 $this->assertFalse($squad->isEligible($user));
         }
     }
+
+    /**
+     * This test checks whether a character from a corp outside an alliance is eligible for a squad with a alliance is not filter.
+     * In SeAT 4, this was not working properly
+     */
+    public function testCharacterHasNoAllianceWithAllianceIsNotFilter(){
+        $squad = new Squad([
+            'name' => 'Testing Squad',
+            'description' => 'Some description',
+            'type' => 'auto',
+            'filters' => json_encode([
+                'and' => [
+                    [
+                        'name' => 'alliance',
+                        'path' => 'characters.affiliation',
+                        'field' => 'alliance_id',
+                        'operator' => '<>',
+                        'criteria' => 99000000,
+                        'text' => 'Random Alliance',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $user = User::first();
+
+        $user->characters->each(function ($character){
+            $character->affiliation->update([
+                'alliance_id' => 99000000,
+            ]);
+        });
+        $this->assertFalse($squad->isEligible($user));
+
+        $user->characters->each(function ($character){
+            $character->affiliation->update([
+                'alliance_id' => null,
+            ]);
+        });
+        $this->assertTrue($squad->isEligible($user));
+    }
 }

--- a/tests/Squads/NoRulesTest.php
+++ b/tests/Squads/NoRulesTest.php
@@ -102,10 +102,8 @@ class NoRulesTest extends TestCase
         // pickup users
         $user = User::first();
 
-        $this->expectException(InvalidFilterException::class);
-
         // ensure no users are eligible
-        $squad->isEligible($user);
+        $this->assertTrue($squad->isEligible($user), 'Squad without filter is open to anyone');
 
     }
 }

--- a/tests/Squads/NoRulesTest.php
+++ b/tests/Squads/NoRulesTest.php
@@ -27,6 +27,7 @@ use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\RefreshToken;
+use Seat\Web\Exceptions\InvalidFilterException;
 use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 use Seat\Web\WebServiceProvider;
@@ -72,10 +73,10 @@ class NoRulesTest extends TestCase
 
         Event::fake();
 
-        CharacterInfo::factory(50)
+        CharacterInfo::factory(5)
             ->create();
 
-        User::factory(10)
+        User::factory(1)
             ->create()
             ->each(function ($user) {
                 CharacterInfo::whereDoesntHave('refresh_token')->get()
@@ -99,11 +100,12 @@ class NoRulesTest extends TestCase
         ]);
 
         // pickup users
-        $users = User::all();
+        $user = User::first();
+
+        $this->expectException(InvalidFilterException::class);
 
         // ensure no users are eligible
-        foreach ($users as $user) {
-            $this->assertTrue($squad->isEligible($user));
-        }
+        $squad->isEligible($user);
+
     }
 }


### PR DESCRIPTION
## Problem:
@Bluedagger on discord noticed that if a character is not in any alliance, and the squad contains a filter for `alliance is not x`, the user doesn't get added to the squad, even though he should.

## How it has been fixed
While studying the `Filterable` trait code (https://github.com/eveseat/web/blob/c97b7cd1dd8cd5c063415ba0710d4b343dfdfef5/src/Models/Filterable.php), I noticed how messy and broken it was. I really struggled to first pin down the problem, and fixing it was even harder since it would have required to special case `is not` in multiple cases.

Therefore, I decided it's rewrite time! This allowed me to fix the original bug, and additionally:
- Make it more readable: There is no 8 levels deep nested code anymore
- Allow nesting of groups to arbitrary depths
- Add a new test case covering the bug

All squad tests are passing.

Lastly, I added a few files to the gitignore that were generated while running tests, but don't belong on github.