### PR TITLE
Bring Corporation Wallet Ledger Bounty in line with Character Bounty Dashboard

### DIFF
--- a/src/Http/Controllers/Corporation/LedgerController.php
+++ b/src/Http/Controllers/Corporation/LedgerController.php
@@ -60,7 +60,7 @@ class LedgerController extends Controller
         $month = is_null($month) ? date('m') : $month;
 
         $group_column = 'second_party_id';
-        $ref_types = ['bounty_prizes', 'bounty_prize', 'ess_escrow_transfer'];
+        $ref_types = ['bounty_prizes', 'bounty_prize', 'ess_escrow_transfer', 'corporate_reward_payout', 'agent_mission_reward', 'agent_mission_time_bonus_reward'];
 
         $periods = $this->getCorporationLedgerPeriods($corporation->corporation_id, $ref_types);
         $entries = $this->getCorporationLedgerByMonth($corporation->corporation_id, $group_column, $ref_types, $year, $month);


### PR DESCRIPTION
As of https://github.com/eveseat/web/pull/643 character bounty payouts on the dashboard reflect bounties, incursion style payouts, and mission rewards.

This PR would bring the corporation bounty ledger inline with that readout.