### PR TITLE
Fix null typeName

### DIFF
--- a/src/resources/views/character/sheet.blade.php
+++ b/src/resources/views/character/sheet.blade.php
@@ -31,7 +31,7 @@
               <dt>{{ trans('web::seat.curr_training') }}</dt>
               <dd>
                 @if($character->skill_queue->where('finish_date', '>', carbon())->isNotEmpty())
-                  {{ $character->skill_queue->where('finish_date', '>', carbon())->first()->type->typeName }} to level
+                  {{ $character->skill_queue->where('finish_date', '>', carbon())->first()->type->typeName ?? trans('web::seat.unknown') }} to level
                   <b>{{ $character->skill_queue->where('finish_date', '>', carbon())->first()->finished_level }}</b>
                 @else
                   {{ trans('web::seat.no_skill_training') }}
@@ -60,7 +60,7 @@
                         <span class="col-md-8" data-toggle="tooltip" title=""
                               @if($skill->finish_date != '0000-00-00 00:00:00')
                               data-original-title="Ends {{ human_diff(carbon($skill->finish_date)->toDateString()) }} on {{ carbon($skill->finish_date)->toDateString() }} at {{ carbon($skill->finish_date)->toTimeString() }}"
-                            @endif>{{ $skill->type->typeName }}</span>
+                            @endif>{{ $skill->type->typeName ?? trans('web::seat.unknown') }}</span>
                         <span class="col-md-4">
                           @for($i = 1; $i <= $skill->finished_level; $i++)
                             @if($i == $skill->finished_level)
@@ -267,7 +267,7 @@
             <ul>
 
               @foreach($character->implants as $implant)
-                <li>{{ $implant->type->typeName }}</li>
+                <li>{{ $implant->type->typeName ?? trans('web::seat.unknown') }}</li>
               @endforeach
 
             </ul>


### PR DESCRIPTION
Some of my corp mates fail to load the character sheet because a type is missing from the DB. In that case, just display `unknown`