### PR TITLE
V5 link character use main char scopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "guzzlehttp/guzzle": "^7.0",
     "intervention/image": "^2.0",
     "laravel/framework": "^10.0",
-    "laravel/horizon": "^5.0",
+    "laravel/horizon": "^5.24.4",
     "laravel/socialite": "^5.0",
     "laravel/ui": "^4.0",
     "lasserafn/php-initial-avatar-generator": "^4.2",

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -71,7 +71,7 @@ class SsoController extends Controller
         // in case the user is already authenticated - we're in a link flow
         if (auth()->check()) {
             // attempt to determine a used scopes and apply the same pattern for the newly linked character
-            $token = auth()->user()->refresh_tokens->first();
+            $token = auth()->user()->main_character()->refresh_token;
 
             if (! is_null($token))
                 $used_scopes = $token->scopes;


### PR DESCRIPTION
When a User clicks "Link Character" from the top-right menu, they should be prompted to use the same scopes as their Main Character.

## The Bug

The DB of refresh_tokens by user_id is not ordered naturally by created_at date, so the "first token" logic being replaced here pulls from a character other than Main Character, which means it will use potentially outdated defaults. Whereas the Main Character, being the one people actually use to Login with, is always prompted to use the newest default scopes that the SeAT Admin has chosen.

This fix allows SeAT Admins to change the default profile and provide an easy way for users with many characters linked to quickly updated all of the scopes across all characters.

## Before
- User has to log out of SeAT, log into SeAT with each and every character manually

## After
- User logs out and logs in with Main character, and then Link Character works fluidly thereafter using the new Scopes for the main character