### PR TITLE
Logg out inactive users, and redirected them to the login page

### DIFF
--- a/src/Http/Controllers/Configuration/UserController.php
+++ b/src/Http/Controllers/Configuration/UserController.php
@@ -153,7 +153,20 @@ class UserController extends Controller
     {
         $user = User::findOrFail($user_id);
 
-        $user->active = $user->active == false ? true : false;
+        if ($user->active == true){
+            $user->active = false;
+            event('security.log', [
+                'deactivated account for user ' . $user->name,
+                'userstatus',
+            ]);
+        } else {
+            $user->active = true;
+            event('security.log', [
+                'reactivated account for user ' . $user->name,
+                'userstatus',
+            ]);
+        }
+
         $user->save();
 
         return redirect()->back()

--- a/src/Http/Middleware/UserActive.php
+++ b/src/Http/Middleware/UserActive.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Web\Http\Middleware;
+
+use Closure;
+
+class UserActive
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Seat\Services\Exceptions\SettingException
+     */
+    public function handle($request, Closure $next)
+    {
+
+        if (!auth()->user()->isActive())
+            return redirect()->guest('auth/logout')
+                ->with('error', 'Account is administratively disabled.');
+
+        return $next($request);
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -46,7 +46,7 @@ Route::group([
     // All routes from here require *at least* that the
     // user is authenticated. We also run the localization
     // related logic here for translation support.
-    Route::group(['middleware' => ['auth', 'locale']], function () {
+    Route::group(['middleware' => ['auth', 'locale', 'user.active']], function () {
 
         // The home route does not need any prefixes
         // and or namespacing modifications, so we will

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -261,4 +261,13 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     {
         return $this->admin === true;
     }
+
+    /**
+     * Return whether the user is active or not.
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->active === true;
+    }
 }

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -58,6 +58,7 @@ use Seat\Web\Http\Composers\User;
 use Seat\Web\Http\Middleware\Authenticate;
 use Seat\Web\Http\Middleware\Locale;
 use Seat\Web\Http\Middleware\RegistrationAllowed;
+use Seat\Web\Http\Middleware\UserActive;
 use Seat\Web\Http\Middleware\Requirements;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\Squads\SquadRole;
@@ -275,6 +276,10 @@ class WebServiceProvider extends AbstractSeatPlugin
         // Registration Middleware checks of the app is
         // allowing new user registration to occur.
         $router->aliasMiddleware('registration.status', RegistrationAllowed::class);
+
+        // UserActive Middleware checks if the user is active
+        // and redirects them to the login page if not.
+        $router->aliasMiddleware('user.active', UserActive::class);
     }
 
     /**


### PR DESCRIPTION
Currently a logged in but deactivated user can use seat and all of its plugins with their current permissions set. An inactive user that tries to login will receive an error. This change forces any user that is inactive, to be logged out and redirected to the login page.