### PR TITLE
Granular esi scheduling for characters

### DIFF
--- a/src/Config/web.characterfilter.php
+++ b/src/Config/web.characterfilter.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 return [
     ['name' => 'scopes', 'src' => 'seatcore::fastlookup.scopes', 'path' => 'refresh_token', 'field' => 'scopes', 'label' => 'Scopes'],
     ['name' => 'character', 'src' => 'seatcore::fastlookup.characters', 'path' => '', 'field' => 'character_id', 'label' => 'Character'],

--- a/src/Config/web.characterfilter.php
+++ b/src/Config/web.characterfilter.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    ['name' => 'scopes', 'src' => 'seatcore::fastlookup.scopes', 'path' => 'refresh_token', 'field' => 'scopes', 'label' => 'Scopes'],
+    ['name' => 'character', 'src' => 'seatcore::fastlookup.characters', 'path' => '', 'field' => 'character_id', 'label' => 'Character'],
+    ['name' => 'title', 'src' => 'seatcore::fastlookup.titles', 'path' => 'titles', 'field' => 'id', 'label' => 'Title'],
+    ['name' => 'corporation', 'src' => 'seatcore::fastlookup.corporations', 'path' => 'affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
+    ['name' => 'alliance', 'src' => 'seatcore::fastlookup.alliances', 'path' => 'affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
+    ['name' => 'skill', 'src' => 'seatcore::fastlookup.skills', 'path' => 'skills', 'field' => 'skill_id', 'label' => 'Skill'],
+    ['name' => 'skill_level', 'src' => [['id' => 1, 'text' => 'Level 1'], ['id' => 2, 'text' => 'Level 2'], ['id' => 3, 'text' => 'Level 3'], ['id' => 4, 'text' => 'Level 4'], ['id' => 5, 'text' => 'Level 5']], 'path' => 'skills', 'field' => 'trained_skill_level', 'label' => 'Skill Level'],
+    ['name' => 'type', 'src' => 'seatcore::fastlookup.items', 'path' => 'assets', 'field' => 'type_id', 'label' => 'Item'],
+    ['name' => 'role', 'src' => 'seatcore::fastlookup.roles', 'path' => 'corporation_roles', 'field' => 'role', 'label' => 'Role'],
+];

--- a/src/Events/CharacterFilterDataUpdate.php
+++ b/src/Events/CharacterFilterDataUpdate.php
@@ -3,6 +3,7 @@
 namespace Seat\Web\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Web\Models\User;
 
 /**
@@ -12,13 +13,13 @@ class CharacterFilterDataUpdate
 {
     use SerializesModels;
 
-    public User $user;
+    public CharacterInfo $character;
 
     /**
      * @param User $user
      */
-    public function __construct(User $user)
+    public function __construct(CharacterInfo $character)
     {
-        $this->user = $user;
+        $this->character = $character;
     }
 }

--- a/src/Events/CharacterFilterDataUpdate.php
+++ b/src/Events/CharacterFilterDataUpdate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Seat\Web\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Seat\Web\Models\User;
+
+/**
+ * This event is fired when character filters, like used in squads, need to recompute because the data they are based on changed.
+ */
+class CharacterFilterDataUpdate
+{
+    use SerializesModels;
+
+    public User $user;
+
+    /**
+     * @param User $user
+     */
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Events/CharacterFilterDataUpdate.php
+++ b/src/Events/CharacterFilterDataUpdate.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Web\Events;
 
 use Illuminate\Queue\SerializesModels;
@@ -16,7 +36,7 @@ class CharacterFilterDataUpdate
     public CharacterInfo $character;
 
     /**
-     * @param User $user
+     * @param  User  $user
      */
     public function __construct(CharacterInfo $character)
     {

--- a/src/Http/Composers/CharacterFilter.php
+++ b/src/Http/Composers/CharacterFilter.php
@@ -33,12 +33,11 @@ class CharacterFilter
         // work with raw arrays since the filter code requires an array of objects, and laravel collections don't like to give us that
         $newrules = [];
         foreach ($rules as $rule) {
+            // convert route names to urls, but keep arrays with hardcoded options
             if(is_string($rule['src'])){
                 $rule['src'] = route($rule['src']);
             }
-
             $newrules[] = (object) $rule;
-
         }
 
         $view->with('characterFilterRules', $newrules);

--- a/src/Http/Composers/CharacterFilter.php
+++ b/src/Http/Composers/CharacterFilter.php
@@ -1,7 +1,26 @@
 <?php
 
-namespace Seat\Web\Http\Composers;
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
+namespace Seat\Web\Http\Composers;
 
 use Illuminate\View\View;
 
@@ -9,7 +28,7 @@ class CharacterFilter
 {
     public function compose(View $view)
     {
-        $rules = config("web.characterfilter");
+        $rules = config('web.characterfilter');
 
         // work with raw arrays since the filter code requires an array of objects, and laravel collections don't like to give us that
         $newrules = [];
@@ -22,6 +41,6 @@ class CharacterFilter
 
         }
 
-        $view->with("characterFilterRules", $newrules);
+        $view->with('characterFilterRules', $newrules);
     }
 }

--- a/src/Http/Composers/CharacterFilter.php
+++ b/src/Http/Composers/CharacterFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Seat\Web\Http\Composers;
+
+
+use Illuminate\View\View;
+
+class CharacterFilter
+{
+    public function compose(View $view)
+    {
+        $rules = config("web.characterfilter");
+
+        // work with raw arrays since the filter code requires an array of objects, and laravel collections don't like to give us that
+        $newrules = [];
+        foreach ($rules as $rule) {
+            if(is_string($rule['src'])){
+                $rule['src'] = route($rule['src']);
+            }
+
+            $newrules[] = (object) $rule;
+
+        }
+
+        $view->with("characterFilterRules", $newrules);
+    }
+}

--- a/src/Http/Controllers/Configuration/ScheduleController.php
+++ b/src/Http/Controllers/Configuration/ScheduleController.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Http\Controllers\Configuration;
 
 use Artisan;
 use Illuminate\Http\Request;
+use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\Models\Schedule;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Web\Http\Validation\NewSchedule;
@@ -117,6 +118,10 @@ class ScheduleController extends Controller
         $rule->filter = $request->filters;
         $rule->save();
 
+        RefreshToken::all()->each(function ($token){
+            CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+        });
+
         return redirect()->back()
             ->with('success', 'Character Scheduling Rule added!');
     }
@@ -128,6 +133,10 @@ class ScheduleController extends Controller
         ]);
 
         CharacterSchedulingRule::destroy($request->rule_id);
+
+        RefreshToken::all()->each(function ($token){
+           CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+        });
 
         return redirect()->back()->with('success','Successfully removed character scheduling rule!');
     }

--- a/src/Http/Controllers/Configuration/ScheduleController.php
+++ b/src/Http/Controllers/Configuration/ScheduleController.php
@@ -96,7 +96,7 @@ class ScheduleController extends Controller
             'filters' => 'required|json',
             'name' => 'required|string',
             'time' => 'required|numeric',
-            'timeunit' => 'required|in:hour,day,week'
+            'timeunit' => 'required|in:hour,day,week',
         ]);
 
         // $time_modifier: conversion factor from timeunit to seconds
@@ -118,7 +118,7 @@ class ScheduleController extends Controller
         $rule->filter = $request->filters;
         $rule->save();
 
-        RefreshToken::all()->each(function ($token){
+        RefreshToken::all()->each(function ($token) {
             CharacterSchedulingRule::updateRefreshTokenSchedule($token);
         });
 
@@ -129,15 +129,15 @@ class ScheduleController extends Controller
     public function deleteSchedulingRule(Request $request)
     {
         $request->validate([
-            'rule_id' => 'required|numeric'
+            'rule_id' => 'required|numeric',
         ]);
 
         CharacterSchedulingRule::destroy($request->rule_id);
 
-        RefreshToken::all()->each(function ($token){
+        RefreshToken::all()->each(function ($token) {
            CharacterSchedulingRule::updateRefreshTokenSchedule($token);
         });
 
-        return redirect()->back()->with('success','Successfully removed character scheduling rule!');
+        return redirect()->back()->with('success', 'Successfully removed character scheduling rule!');
     }
 }

--- a/src/Http/Routes/Configuration/Schedule.php
+++ b/src/Http/Routes/Configuration/Schedule.php
@@ -31,3 +31,7 @@ Route::post('/new')
 Route::get('/delete/{schedule_id}')
     ->name('seatcore::configuration.schedule.delete')
     ->uses('ScheduleController@deleteSchedule');
+
+Route::post('/rules/create')
+    ->name('seatcore::configuration.schedule.rule.create')
+    ->uses('ScheduleController@createSchedulingRule');

--- a/src/Listeners/CharacterFilterDataUpdatedSquads.php
+++ b/src/Listeners/CharacterFilterDataUpdatedSquads.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Web\Listeners;
 
 use Seat\Web\Events\CharacterFilterDataUpdate;

--- a/src/Listeners/CharacterFilterDataUpdatedSquads.php
+++ b/src/Listeners/CharacterFilterDataUpdatedSquads.php
@@ -9,7 +9,7 @@ class CharacterFilterDataUpdatedSquads
 {
     public static function handle(CharacterFilterDataUpdate $event)
     {
-        $user = $event->user;
+        $user = $event->character->user;
 
         $member_squads = $user->squads;
 

--- a/src/Listeners/CharacterFilterDataUpdatedSquads.php
+++ b/src/Listeners/CharacterFilterDataUpdatedSquads.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Seat\Web\Listeners;
+
+use Seat\Web\Events\CharacterFilterDataUpdate;
+use Seat\Web\Models\Squads\Squad;
+
+class CharacterFilterDataUpdatedSquads
+{
+    public static function handle(CharacterFilterDataUpdate $event)
+    {
+        $user = $event->user;
+
+        $member_squads = $user->squads;
+
+        // retrieve all auto squads from which the user is not already a member.
+        $other_squads = Squad::where('type', 'auto')->whereDoesntHave('members', function ($query) use ($user) {
+            $query->where('id', $user->id);
+        })->get();
+
+        // remove the user from squads to which he's non longer eligible.
+        $member_squads->each(function (Squad $squad) use ($user) {
+            if (! $squad->isUserEligible($user))
+                $squad->members()->detach($user->id);
+        });
+
+        // add the user to squads from which he's not already a member.
+        $other_squads->each(function (Squad $squad) use ($user) {
+            if ($squad->isUserEligible($user))
+                $squad->members()->save($user);
+        });
+    }
+}

--- a/src/Listeners/CharacterFilterDataUpdatedTokens.php
+++ b/src/Listeners/CharacterFilterDataUpdatedTokens.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Web\Listeners;
 
 use Seat\Web\Events\CharacterFilterDataUpdate;

--- a/src/Listeners/CharacterFilterDataUpdatedTokens.php
+++ b/src/Listeners/CharacterFilterDataUpdatedTokens.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Seat\Web\Listeners;
+
+use Seat\Web\Events\CharacterFilterDataUpdate;
+use Seat\Web\Models\CharacterSchedulingRule;
+
+class CharacterFilterDataUpdatedTokens
+{
+    public static function handle(CharacterFilterDataUpdate $update)
+    {
+        CharacterSchedulingRule::updateRefreshTokenSchedule($update->character->refresh_token);
+    }
+}

--- a/src/Models/CharacterSchedulingRule.php
+++ b/src/Models/CharacterSchedulingRule.php
@@ -20,22 +20,23 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-Route::get('/')
-    ->name('seatcore::configuration.schedule')
-    ->uses('ScheduleController@listSchedule');
+namespace Seat\Web\Models;
 
-Route::post('/new')
-    ->name('seatcore::configuration.schedule.new')
-    ->uses('ScheduleController@newSchedule');
+use Carbon\Carbon;
+use Seat\Eveapi\Models\RefreshToken;
+use Seat\Eveapi\Models\RefreshTokenSchedule;
+use Seat\Services\Models\ExtensibleModel;
 
-Route::get('/delete/{schedule_id}')
-    ->name('seatcore::configuration.schedule.delete')
-    ->uses('ScheduleController@deleteSchedule');
-
-Route::post('/rules/create')
-    ->name('seatcore::configuration.schedule.rule.create')
-    ->uses('ScheduleController@createSchedulingRule');
-
-Route::post('/rules/delete')
-    ->name('seatcore::configuration.schedule.rule.delete')
-    ->uses('ScheduleController@deleteSchedulingRule');
+/**
+ * @property int $id
+ * @property string name
+ * @property string filter
+ * @property int interval
+ */
+class CharacterSchedulingRule extends ExtensibleModel
+{
+    /**
+     * @var bool
+     */
+    public $timestamps = false;
+}

--- a/src/Models/CharacterSchedulingRule.php
+++ b/src/Models/CharacterSchedulingRule.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Models;
 
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\RefreshToken;
+use Seat\Eveapi\Models\RefreshTokenSchedule;
 use Seat\Services\Models\ExtensibleModel;
 use stdClass;
 
@@ -61,6 +62,12 @@ class CharacterSchedulingRule extends ExtensibleModel
     public static function updateRefreshTokenSchedule(RefreshToken $token): void
     {
         $schedule = $token->token_schedule;
+
+        if($schedule === null) {
+            $schedule = new RefreshTokenSchedule();
+            $schedule->character_id = $token->character_id;
+        }
+
         $schedule->update_interval = self::getCharacterSchedulingInterval($token->character);
         $schedule->save();
     }

--- a/src/Models/CharacterSchedulingRule.php
+++ b/src/Models/CharacterSchedulingRule.php
@@ -53,9 +53,9 @@ class CharacterSchedulingRule extends ExtensibleModel
     }
 
     /**
-     * Recomputes the update interval of a character and saves it in the refresh_token_schedules table
+     * Recomputes the update interval of a character and saves it in the refresh_token_schedules table.
      *
-     * @param RefreshToken $token
+     * @param  RefreshToken  $token
      * @return void
      */
     public static function updateRefreshTokenSchedule(RefreshToken $token): void
@@ -66,9 +66,9 @@ class CharacterSchedulingRule extends ExtensibleModel
     }
 
     /**
-     * Computes the scheduling interval from the character scheduling rules for a character
+     * Computes the scheduling interval from the character scheduling rules for a character.
      *
-     * @param CharacterInfo $character
+     * @param  CharacterInfo  $character
      * @return int
      */
     private static function getCharacterSchedulingInterval(CharacterInfo $character): int
@@ -81,6 +81,6 @@ class CharacterSchedulingRule extends ExtensibleModel
             }
         }
 
-        return 60*60; // 1 hour
+        return 60 * 60; // 1 hour
     }
 }

--- a/src/Observers/AbstractCharacterFilterObserver.php
+++ b/src/Observers/AbstractCharacterFilterObserver.php
@@ -26,7 +26,6 @@ use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Web\Events\CharacterFilterDataUpdate;
 use Seat\Web\Exceptions\InvalidFilterException;
-use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 
 /**

--- a/src/Observers/AbstractCharacterFilterObserver.php
+++ b/src/Observers/AbstractCharacterFilterObserver.php
@@ -23,6 +23,7 @@
 namespace Seat\Web\Observers;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Web\Events\CharacterFilterDataUpdate;
 use Seat\Web\Exceptions\InvalidFilterException;
 use Seat\Web\Models\Squads\Squad;
@@ -39,9 +40,9 @@ abstract class AbstractCharacterFilterObserver
      * Return the User owning the model which fired the catch event.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
-     * @return \Seat\Web\Models\User|null The user owning this model
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    abstract protected function findRelatedUser(Model $fired_model): ?User;
+    abstract protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo;
 
     /**
      * Update squads to which the user owning model firing the event is member.
@@ -52,11 +53,11 @@ abstract class AbstractCharacterFilterObserver
      */
     protected function fireCharacterFilterEvent(Model $fired_model): void
     {
-        $user = $this->findRelatedUser($fired_model);
+        $character = $this->findRelatedCharacter($fired_model);
 
-        if (! $user)
+        if (! $character)
             return;
 
-        event(new CharacterFilterDataUpdate($user));
+        event(new CharacterFilterDataUpdate($character));
     }
 }

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Observers;
 
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Web\Models\User;
 
 /**
@@ -50,15 +51,13 @@ class CharacterAffiliationObserver extends AbstractCharacterFilterObserver
     }
 
     /**
-     * {@inheritdoc}
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    protected function findRelatedUser(Model $fired_model): ?User
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        // retrieve user related to the character affiliation
-        return User::with('squads')
-            ->standard()
-            ->whereHas('characters', function ($query) use ($fired_model) {
-                $query->where('character_infos.character_id', $fired_model->character_id);
-            })->first();
+        return $fired_model->character;
     }
 }

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -31,14 +31,14 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class CharacterAffiliationObserver extends AbstractSquadObserver
+class CharacterAffiliationObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\Character\CharacterAffiliation  $affiliation
      */
     public function created(CharacterAffiliation $affiliation)
     {
-        $this->updateUserSquads($affiliation);
+        $this->fireCharacterFilterEvent($affiliation);
     }
 
     /**
@@ -46,7 +46,7 @@ class CharacterAffiliationObserver extends AbstractSquadObserver
      */
     public function updated(CharacterAffiliation $affiliation)
     {
-        $this->updateUserSquads($affiliation);
+        $this->fireCharacterFilterEvent($affiliation);
     }
 
     /**

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -53,7 +53,7 @@ class CharacterAffiliationObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -58,6 +58,7 @@ class CharacterAffiliationObserver extends AbstractCharacterFilterObserver
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        return $fired_model->character;
+        // CharacterAffiliation links to UniverseName instead of CharacterInfo
+        return CharacterInfo::find($fired_model->character_id);
     }
 }

--- a/src/Observers/CharacterAssetObserver.php
+++ b/src/Observers/CharacterAssetObserver.php
@@ -31,14 +31,14 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class CharacterAssetObserver extends AbstractSquadObserver
+class CharacterAssetObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\Assets\CharacterAsset  $asset
      */
     public function created(CharacterAsset $asset)
     {
-        $this->updateUserSquads($asset);
+        $this->fireCharacterFilterEvent($asset);
     }
 
     /**
@@ -46,7 +46,7 @@ class CharacterAssetObserver extends AbstractSquadObserver
      */
     public function updated(CharacterAsset $asset)
     {
-        $this->updateUserSquads($asset);
+        $this->fireCharacterFilterEvent($asset);
     }
 
     /**
@@ -54,7 +54,7 @@ class CharacterAssetObserver extends AbstractSquadObserver
      */
     public function deleted(CharacterAsset $asset)
     {
-        $this->updateUserSquads($asset);
+        $this->fireCharacterFilterEvent($asset);
     }
 
     /**

--- a/src/Observers/CharacterAssetObserver.php
+++ b/src/Observers/CharacterAssetObserver.php
@@ -24,6 +24,7 @@ namespace Seat\Web\Observers;
 
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Web\Models\User;
 
 /**
@@ -58,15 +59,13 @@ class CharacterAssetObserver extends AbstractCharacterFilterObserver
     }
 
     /**
-     * {@inheritdoc}
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    protected function findRelatedUser(Model $fired_model): ?User
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        // retrieve user related to the character affiliation
-        return User::with('squads')
-            ->standard()
-            ->whereHas('characters', function ($query) use ($fired_model) {
-                $query->where('character_infos.character_id', $fired_model->character_id);
-            })->first();
+        return $fired_model->character;
     }
 }

--- a/src/Observers/CharacterAssetObserver.php
+++ b/src/Observers/CharacterAssetObserver.php
@@ -61,7 +61,7 @@ class CharacterAssetObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/CharacterRoleObserver.php
+++ b/src/Observers/CharacterRoleObserver.php
@@ -34,14 +34,14 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class CharacterRoleObserver extends AbstractSquadObserver
+class CharacterRoleObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\Character\CharacterRole  $role
      */
     public function created(CharacterRole $role)
     {
-        $this->updateUserSquads($role);
+        $this->fireCharacterFilterEvent($role);
 
         // in case the created role is not a Director role, ignore
         if ($role->role != 'Director')
@@ -67,7 +67,7 @@ class CharacterRoleObserver extends AbstractSquadObserver
      */
     public function updated(CharacterRole $role)
     {
-        $this->updateUserSquads($role);
+        $this->fireCharacterFilterEvent($role);
     }
 
     /**
@@ -75,7 +75,7 @@ class CharacterRoleObserver extends AbstractSquadObserver
      */
     public function deleted(CharacterRole $role)
     {
-        $this->updateUserSquads($role);
+        $this->fireCharacterFilterEvent($role);
     }
 
     /**

--- a/src/Observers/CharacterRoleObserver.php
+++ b/src/Observers/CharacterRoleObserver.php
@@ -25,6 +25,7 @@ namespace Seat\Web\Observers;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Bus\Corporation;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterRole;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Web\Models\User;
@@ -79,15 +80,13 @@ class CharacterRoleObserver extends AbstractCharacterFilterObserver
     }
 
     /**
-     * {@inheritdoc}
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    protected function findRelatedUser(Model $fired_model): ?User
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        // retrieve user related to the character affiliation
-        return User::with('squads')
-            ->standard()
-            ->whereHas('characters', function ($query) use ($fired_model) {
-                $query->where('character_infos.character_id', $fired_model->character_id);
-            })->first();
+        return $fired_model->character;
     }
 }

--- a/src/Observers/CharacterRoleObserver.php
+++ b/src/Observers/CharacterRoleObserver.php
@@ -82,7 +82,7 @@ class CharacterRoleObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/CharacterSkillObserver.php
+++ b/src/Observers/CharacterSkillObserver.php
@@ -31,14 +31,14 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class CharacterSkillObserver extends AbstractSquadObserver
+class CharacterSkillObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\Character\CharacterSkill  $skill
      */
     public function created(CharacterSkill $skill)
     {
-        $this->updateUserSquads($skill);
+        $this->fireCharacterFilterEvent($skill);
     }
 
     /**
@@ -46,7 +46,7 @@ class CharacterSkillObserver extends AbstractSquadObserver
      */
     public function updated(CharacterSkill $skill)
     {
-        $this->updateUserSquads($skill);
+        $this->fireCharacterFilterEvent($skill);
     }
 
     /**
@@ -54,7 +54,7 @@ class CharacterSkillObserver extends AbstractSquadObserver
      */
     public function deleted(CharacterSkill $skill)
     {
-        $this->updateUserSquads($skill);
+        $this->fireCharacterFilterEvent($skill);
     }
 
     /**

--- a/src/Observers/CharacterSkillObserver.php
+++ b/src/Observers/CharacterSkillObserver.php
@@ -23,6 +23,7 @@
 namespace Seat\Web\Observers;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterSkill;
 use Seat\Web\Models\User;
 
@@ -68,5 +69,16 @@ class CharacterSkillObserver extends AbstractCharacterFilterObserver
             ->whereHas('characters', function ($query) use ($fired_model) {
                 $query->where('character_infos.character_id', $fired_model->character_id);
             })->first();
+    }
+
+    /**
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
+     */
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
+    {
+        return $fired_model->character;
     }
 }

--- a/src/Observers/CharacterSkillObserver.php
+++ b/src/Observers/CharacterSkillObserver.php
@@ -74,7 +74,7 @@ class CharacterSkillObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/CharacterTitleObserver.php
+++ b/src/Observers/CharacterTitleObserver.php
@@ -61,7 +61,7 @@ class CharacterTitleObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/CharacterTitleObserver.php
+++ b/src/Observers/CharacterTitleObserver.php
@@ -23,6 +23,7 @@
 namespace Seat\Web\Observers;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Pivot\Character\CharacterTitle;
 use Seat\Web\Models\User;
 
@@ -58,15 +59,13 @@ class CharacterTitleObserver extends AbstractCharacterFilterObserver
     }
 
     /**
-     * {@inheritdoc}
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    protected function findRelatedUser(Model $fired_model): ?User
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        // retrieve user related to the character affiliation
-        return User::with('squads')
-            ->standard()
-            ->whereHas('characters', function ($query) use ($fired_model) {
-                $query->where('character_infos.character_id', $fired_model->character_id);
-            })->first();
+        return CharacterInfo::find($fired_model->character_id);
     }
 }

--- a/src/Observers/CharacterTitleObserver.php
+++ b/src/Observers/CharacterTitleObserver.php
@@ -31,14 +31,14 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class CharacterTitleObserver extends AbstractSquadObserver
+class CharacterTitleObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\Assets\CharacterAsset  $asset
      */
     public function created(CharacterTitle $title)
     {
-        $this->updateUserSquads($title);
+        $this->fireCharacterFilterEvent($title);
     }
 
     /**
@@ -46,7 +46,7 @@ class CharacterTitleObserver extends AbstractSquadObserver
      */
     public function updated(CharacterTitle $title)
     {
-        $this->updateUserSquads($title);
+        $this->fireCharacterFilterEvent($title);
     }
 
     /**
@@ -54,7 +54,7 @@ class CharacterTitleObserver extends AbstractSquadObserver
      */
     public function deleted(CharacterTitle $title)
     {
-        $this->updateUserSquads($title);
+        $this->fireCharacterFilterEvent($title);
     }
 
     /**

--- a/src/Observers/RefreshTokenObserver.php
+++ b/src/Observers/RefreshTokenObserver.php
@@ -103,7 +103,7 @@ class RefreshTokenObserver extends AbstractCharacterFilterObserver
     /**
      * Return the User owning the model which fired the catch event.
      *
-     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @param  \Illuminate\Database\Eloquent\Model  $fired_model  The model which fired the catch event
      * @return ?CharacterInfo The character that is affected by this update
      */
     protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo

--- a/src/Observers/RefreshTokenObserver.php
+++ b/src/Observers/RefreshTokenObserver.php
@@ -33,7 +33,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Web\Observers
  */
-class RefreshTokenObserver extends AbstractSquadObserver
+class RefreshTokenObserver extends AbstractCharacterFilterObserver
 {
     /**
      * @param  \Seat\Eveapi\Models\RefreshToken  $token
@@ -45,7 +45,7 @@ class RefreshTokenObserver extends AbstractSquadObserver
             $job->fire();
 
             // enqueue squads update
-            $this->updateUserSquads($token);
+            $this->fireCharacterFilterEvent($token);
         } catch (Exception $e) {
             logger()->error($e->getMessage());
         }
@@ -57,7 +57,7 @@ class RefreshTokenObserver extends AbstractSquadObserver
     public function updated(RefreshToken $token)
     {
         try {
-            $this->updateUserSquads($token);
+            $this->fireCharacterFilterEvent($token);
         } catch (Exception $e) {
             logger()->error($e->getMessage());
         }
@@ -77,7 +77,7 @@ class RefreshTokenObserver extends AbstractSquadObserver
     public function deleted(RefreshToken $token)
     {
         try {
-            $this->updateUserSquads($token);
+            $this->fireCharacterFilterEvent($token);
         } catch (Exception $e) {
             logger()->error($e->getMessage());
         }
@@ -93,7 +93,7 @@ class RefreshTokenObserver extends AbstractSquadObserver
             $job->fire();
 
             // enqueue squads update
-            $this->updateUserSquads($token);
+            $this->fireCharacterFilterEvent($token);
         } catch (Exception $e) {
             logger()->error($e->getMessage());
         }

--- a/src/Observers/RefreshTokenObserver.php
+++ b/src/Observers/RefreshTokenObserver.php
@@ -25,6 +25,7 @@ namespace Seat\Web\Observers;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Bus\Character;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Web\Models\User;
 
@@ -100,11 +101,13 @@ class RefreshTokenObserver extends AbstractCharacterFilterObserver
     }
 
     /**
-     * {@inheritdoc}
+     * Return the User owning the model which fired the catch event.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $fired_model The model which fired the catch event
+     * @return ?CharacterInfo The character that is affected by this update
      */
-    protected function findRelatedUser(Model $fired_model): ?User
+    protected function findRelatedCharacter(Model $fired_model): ?CharacterInfo
     {
-        return User::with('squads')
-            ->find($fired_model->user_id);
+        return $fired_model->character;
     }
 }

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -63,6 +63,7 @@ use Seat\Web\Http\Middleware\Locale;
 use Seat\Web\Http\Middleware\RegistrationAllowed;
 use Seat\Web\Http\Middleware\Requirements;
 use Seat\Web\Listeners\CharacterFilterDataUpdatedSquads;
+use Seat\Web\Listeners\CharacterFilterDataUpdatedTokens;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\Squads\SquadRole;
 use Seat\Web\Observers\CharacterAffiliationObserver;
@@ -302,6 +303,7 @@ class WebServiceProvider extends AbstractSeatPlugin
         // Custom Events
         Event::listen('security.log', SecLog::class);
         Event::listen(CharacterFilterDataUpdate::class, CharacterFilterDataUpdatedSquads::class);
+        Event::listen(CharacterFilterDataUpdate::class, CharacterFilterDataUpdatedTokens::class);
 
         // Characters / Corporations first auth - Jobs Events
         CharacterRole::observe(CharacterRoleObserver::class);

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -50,6 +50,7 @@ use Seat\Web\Events\Logout;
 use Seat\Web\Events\SecLog;
 use Seat\Web\Http\Composers\AllianceLayout;
 use Seat\Web\Http\Composers\AllianceMenu;
+use Seat\Web\Http\Composers\CharacterFilter;
 use Seat\Web\Http\Composers\CharacterLayout;
 use Seat\Web\Http\Composers\CharacterMenu;
 use Seat\Web\Http\Composers\CorporationLayout;
@@ -246,6 +247,11 @@ class WebServiceProvider extends AbstractSeatPlugin
             'web::alliance.layouts.view',
         ], AllianceLayout::class);
 
+        // Squad filter rules
+        $this->app['view']->composer([
+            'web::squads.edit',
+            'web::squads.create',
+        ], CharacterFilter::class);
     }
 
     /**
@@ -350,6 +356,8 @@ class WebServiceProvider extends AbstractSeatPlugin
             __DIR__ . '/Config/web.locale.php', 'web.locale');
         $this->mergeConfigFrom(
             __DIR__ . '/Config/web.skins.php', 'web.skins');
+        $this->mergeConfigFrom(
+            __DIR__ . '/Config/web.characterfilter.php', 'web.characterfilter');
 
         // Menu Configurations
         $this->mergeConfigFrom(

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Auth\Events\Logout as LogoutEvent;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Horizon\Horizon;
@@ -43,6 +44,7 @@ use Seat\Services\Settings\Seat;
 use Seat\Web\Commands\Seat\Admin\Login as AdminLogin;
 use Seat\Web\Database\Seeders\ScheduleSeeder;
 use Seat\Web\Events\Attempt;
+use Seat\Web\Events\CharacterFilterDataUpdate;
 use Seat\Web\Events\Login;
 use Seat\Web\Events\Logout;
 use Seat\Web\Events\SecLog;
@@ -59,6 +61,7 @@ use Seat\Web\Http\Middleware\Authenticate;
 use Seat\Web\Http\Middleware\Locale;
 use Seat\Web\Http\Middleware\RegistrationAllowed;
 use Seat\Web\Http\Middleware\Requirements;
+use Seat\Web\Listeners\CharacterFilterDataUpdatedSquads;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\Squads\SquadRole;
 use Seat\Web\Observers\CharacterAffiliationObserver;
@@ -285,12 +288,13 @@ class WebServiceProvider extends AbstractSeatPlugin
     {
 
         // Internal Authentication Events
-        $this->app->events->listen(LoginEvent::class, Login::class);
-        $this->app->events->listen(LogoutEvent::class, Logout::class);
-        $this->app->events->listen(Attempting::class, Attempt::class);
+        Event::listen(LoginEvent::class, Login::class);
+        Event::listen(LogoutEvent::class, Logout::class);
+        Event::listen(Attempting::class, Attempt::class);
 
         // Custom Events
-        $this->app->events->listen('security.log', SecLog::class);
+        Event::listen('security.log', SecLog::class);
+        Event::listen(CharacterFilterDataUpdate::class, CharacterFilterDataUpdatedSquads::class);
 
         // Characters / Corporations first auth - Jobs Events
         CharacterRole::observe(CharacterRoleObserver::class);

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -252,7 +252,7 @@ class WebServiceProvider extends AbstractSeatPlugin
         $this->app['view']->composer([
             'web::squads.edit',
             'web::squads.create',
-            'web::configuration.schedule.view'
+            'web::configuration.schedule.view',
         ], CharacterFilter::class);
     }
 

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -251,6 +251,7 @@ class WebServiceProvider extends AbstractSeatPlugin
         $this->app['view']->composer([
             'web::squads.edit',
             'web::squads.create',
+            'web::configuration.schedule.view'
         ], CharacterFilter::class);
     }
 

--- a/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
+++ b/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use \Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('character_scheduling_rules', function (Blueprint $table) {
+            $table->bigIncrements('id')->primary();
+            $table->string("name");
+            $table->integer("interval")->unsigned();
+            $table->json("filter");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('character_scheduling_rules');
+    }
+};

--- a/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
+++ b/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
@@ -1,6 +1,26 @@
 <?php
 
-use \Illuminate\Database\Migrations\Migration;
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -14,9 +34,9 @@ return new class extends Migration {
     {
         Schema::create('character_scheduling_rules', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string("name");
-            $table->integer("interval")->unsigned();
-            $table->json("filter");
+            $table->string('name');
+            $table->integer('interval')->unsigned();
+            $table->json('filter');
         });
     }
 

--- a/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
+++ b/src/database/migrations/2024_08_15_create_character_scheduling_rules_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::create('character_scheduling_rules', function (Blueprint $table) {
-            $table->bigIncrements('id')->primary();
+            $table->bigIncrements('id');
             $table->string("name");
             $table->integer("interval")->unsigned();
             $table->json("filter");

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -103,6 +103,7 @@ return [
     'hour' => 'hour',
     'week' => 'week',
     'day' => 'day',
+    'save' => 'Save',
 
     // Requirements
     'requirements' => 'Requirements',
@@ -379,10 +380,13 @@ return [
     'scheduled_commands' => 'Scheduled Commands',
     'choose_prepop' => 'Choose a pre-populated cron expression, or write your own.',
     'add_scheduled' => 'Add Scheduled Command',
+    'character_scheduling_rule'=>'character scheduling rule',
     'character_scheduling_rules' => 'Character Scheduling Rules',
     'new_character_scheduling_rule' => 'New Character Scheduling Rule',
     'update_interval' => 'Update Interval',
     'name_input_placeholder' => 'Enter a name...',
+    'character_scheduling_rules_empty' => 'There are no character scheduling rules defined, using a default of one hour for everyone.',
+    'character_scheduling_rules_default' => 'When no rules apply to a character, an update interval of one hour is used.',
 
 
     // Security

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -380,14 +380,13 @@ return [
     'scheduled_commands' => 'Scheduled Commands',
     'choose_prepop' => 'Choose a pre-populated cron expression, or write your own.',
     'add_scheduled' => 'Add Scheduled Command',
-    'character_scheduling_rule'=>'character scheduling rule',
+    'character_scheduling_rule' => 'character scheduling rule',
     'character_scheduling_rules' => 'Character Scheduling Rules',
     'new_character_scheduling_rule' => 'New Character Scheduling Rule',
     'update_interval' => 'Update Interval',
     'name_input_placeholder' => 'Enter a name...',
     'character_scheduling_rules_empty' => 'There are no character scheduling rules defined, using a default of one hour for everyone.',
     'character_scheduling_rules_default' => 'When no rules apply to a character, an update interval of one hour is used.',
-
 
     // Security
     'category' => 'Category',

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -99,6 +99,10 @@ return [
     'token_status_valid' => 'This character has a valid registered token.',
     'token_status_invalid' => 'You don\'t own any valid token for this character.',
     'set_default' => 'Set Default',
+    'rule' => 'Rule|Rules',
+    'hour' => 'hour',
+    'week' => 'week',
+    'day' => 'day',
 
     // Requirements
     'requirements' => 'Requirements',
@@ -375,6 +379,11 @@ return [
     'scheduled_commands' => 'Scheduled Commands',
     'choose_prepop' => 'Choose a pre-populated cron expression, or write your own.',
     'add_scheduled' => 'Add Scheduled Command',
+    'character_scheduling_rules' => 'Character Scheduling Rules',
+    'new_character_scheduling_rule' => 'New Character Scheduling Rule',
+    'update_interval' => 'Update Interval',
+    'name_input_placeholder' => 'Enter a name...',
+
 
     // Security
     'category' => 'Category',

--- a/src/resources/views/components/filters/buttons/filters.blade.php
+++ b/src/resources/views/components/filters/buttons/filters.blade.php
@@ -1,3 +1,3 @@
-<button data-toggle="modal" data-target="#filters-modal" class="btn btn-sm btn-warning" id="filters-btn" data-filters="{{ $rules ?: '{}' }}">
-  <i class="fas fa-sliders-h"></i> Filters
+<button data-toggle="modal" data-target="#filters-modal" class="btn btn-sm btn-warning" id="filters-btn" data-filters="{{ $rules ?: '{}' }}" type="button">
+  <i class="fas fa-sliders-h"></i> {{$buttonText ?? trans_choice('web::seat.filter', 1)}}
 </button>

--- a/src/resources/views/configuration/schedule/view.blade.php
+++ b/src/resources/views/configuration/schedule/view.blade.php
@@ -162,7 +162,7 @@
               @include('web::components.filters.buttons.filters', ['rules' => [], 'buttonText'=>'Configure Character Filter'])
             </div>
 
-            <input type="hidden" name="filters" value="{}" />
+            <input type="hidden" name="filters" value="{}"/>
 
             <button type="submit" class="btn btn-success float-right">
               <i class="fas fa-plus-square"></i>
@@ -188,29 +188,32 @@
             </tr>
             </thead>
             <tbody>
-              @foreach($scheduling_rules as $scheduling_rule)
-                <tr>
-                  <td>{{ $scheduling_rule->name }}</td>
-                  <td>{{ \Carbon\CarbonInterval::seconds($scheduling_rule->interval)->cascade() }}</td>
-                  <td class="d-flex flex-row align-items-center justify-content-end">
-                      <button type="button" class="btn btn-success btn-sm btn-edit-rule mx-2" data-filter="{{$scheduling_rule->filter}}" data-name="{{$scheduling_rule->name}}" data-interval="{{$scheduling_rule->interval}}">{{ trans('web::seat.edit') }}</button>
+            @foreach($scheduling_rules as $scheduling_rule)
+              <tr>
+                <td>{{ $scheduling_rule->name }}</td>
+                <td>{{ \Carbon\CarbonInterval::seconds($scheduling_rule->interval)->cascade() }}</td>
+                <td class="d-flex flex-row align-items-center justify-content-end">
+                  <button type="button" class="btn btn-success btn-sm btn-edit-rule mx-2"
+                          data-filter="{{$scheduling_rule->filter}}" data-name="{{$scheduling_rule->name}}"
+                          data-interval="{{$scheduling_rule->interval}}">{{ trans('web::seat.edit') }}</button>
 
-                      <form action="{{ route('seatcore::configuration.schedule.rule.delete') }}" method="POST">
-                        @csrf
-                        <input type="hidden" name="rule_id" value="{{$scheduling_rule->id}}">
-                        <button type="submit" class="btn btn-danger btn-sm confirmdelete" data-seat-entity="{{trans('web::seat.character_scheduling_rule')}}">{{ trans('web::seat.delete') }}</button>
-                      </form>
-                  </td>
-                </tr>
-              @endforeach
+                  <form action="{{ route('seatcore::configuration.schedule.rule.delete') }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="rule_id" value="{{$scheduling_rule->id}}">
+                    <button type="submit" class="btn btn-danger btn-sm confirmdelete"
+                            data-seat-entity="{{trans('web::seat.character_scheduling_rule')}}">{{ trans('web::seat.delete') }}</button>
+                  </form>
+                </td>
+              </tr>
+            @endforeach
 
-                <tr>
-                  <td colspan="3" class="text-center">
-                    @if($scheduling_rules->isEmpty())
-                      {{trans('web::seat.character_scheduling_rules_empty')}}
-                    @endif
-                  </td>
-                </tr>
+            @if($scheduling_rules->isEmpty())
+              <tr>
+                <td colspan="3" class="text-center">
+                  {{trans('web::seat.character_scheduling_rules_empty')}}
+                </td>
+              </tr>
+            @endif
             </tbody>
           </table>
           @if(!$scheduling_rules->isEmpty())
@@ -251,10 +254,10 @@
           $('input[name="filters"]').val(document.getElementById('filters-btn').dataset.filters);
       });
 
-      $('.btn-edit-rule').on('click', function (){
-          $('#filters-btn').attr('data-filters',$(this).attr('data-filter'))
+      $('.btn-edit-rule').on('click', function () {
+          $('#filters-btn').attr('data-filters', $(this).attr('data-filter'))
           $('#rule-name').val($(this).data('name'))
-          $('#time').val($(this).data('interval')/3600)
+          $('#time').val($(this).data('interval') / 3600)
           $('#timeunit').val("hour")
           $(this).blur()
       })

--- a/src/resources/views/configuration/schedule/view.blade.php
+++ b/src/resources/views/configuration/schedule/view.blade.php
@@ -137,7 +137,7 @@
           <h3 class="card-title">{{ trans('web::seat.new_character_scheduling_rule') }}</h3>
         </div>
         <div class="card-body">
-          <form action="{{ route('seatcore::configuration.schedule.rule.create') }}" method="POST">
+          <form action="{{ route('seatcore::configuration.schedule.rule.create') }}" method="POST" id="rule-form">
             @csrf
 
             <div class="form-group">
@@ -150,7 +150,7 @@
               <label for="time">{{ trans('web::seat.update_interval') }}</label>
               <div class="row mx-0">
                 <input class="form-control col-md-9" type="number" name="time" value="1" min="1" step="0.01" id="time">
-                <select name="timeunit" class="form-control col-md-3">
+                <select name="timeunit" class="form-control col-md-3" id="timeunit">
                   <option selected value="hour">{{trans('web::seat.hour')}}</option>
                   <option value="day">{{trans('web::seat.day')}}</option>
                   <option value="week">{{trans('web::seat.week')}}</option>
@@ -166,7 +166,7 @@
 
             <button type="submit" class="btn btn-success float-right">
               <i class="fas fa-plus-square"></i>
-              {{trans('web::seat.add')}}
+              {{trans('web::seat.save')}}
             </button>
           </form>
         </div>
@@ -184,17 +184,43 @@
             <tr>
               <th>{{trans_choice('web::seat.rule', 1)}}</th>
               <th>{{trans('web::seat.update_interval')}}</th>
-              <th>{{trans('web::seat.action')}}</th>
+              <th class="text-right">{{trans('web::seat.action')}}</th>
             </tr>
             </thead>
             <tbody>
+              @foreach($scheduling_rules as $scheduling_rule)
+                <tr>
+                  <td>{{ $scheduling_rule->name }}</td>
+                  <td>{{ \Carbon\CarbonInterval::seconds($scheduling_rule->interval)->cascade() }}</td>
+                  <td class="d-flex flex-row align-items-center justify-content-end">
+                      <button type="button" class="btn btn-success btn-sm btn-edit-rule mx-2" data-filter="{{$scheduling_rule->filter}}" data-name="{{$scheduling_rule->name}}" data-interval="{{$scheduling_rule->interval}}">{{ trans('web::seat.edit') }}</button>
 
+                      <form action="{{ route('seatcore::configuration.schedule.rule.delete') }}" method="POST">
+                        @csrf
+                        <input type="hidden" name="rule_id" value="{{$scheduling_rule->id}}">
+                        <button type="submit" class="btn btn-danger btn-sm confirmdelete" data-seat-entity="{{trans('web::seat.character_scheduling_rule')}}">{{ trans('web::seat.delete') }}</button>
+                      </form>
+                  </td>
+                </tr>
+              @endforeach
+
+                <tr>
+                  <td colspan="3" class="text-center">
+                    @if($scheduling_rules->isEmpty())
+                      {{trans('web::seat.character_scheduling_rules_empty')}}
+                    @endif
+                  </td>
+                </tr>
             </tbody>
           </table>
+          @if(!$scheduling_rules->isEmpty())
+            <p class="text-muted">
+              {{trans('web::seat.character_scheduling_rules_default')}}
+            </p>
+          @endif
         </div>
       </div>
     </div>
-
   </div>
 
 
@@ -218,6 +244,20 @@
           $("span#expression").html(
               "Cron: <b>" + this.value.replace("<", "") + "</b>");
       });
+  </script>
+
+  <script>
+      $('#rule-form').on('submit', function () {
+          $('input[name="filters"]').val(document.getElementById('filters-btn').dataset.filters);
+      });
+
+      $('.btn-edit-rule').on('click', function (){
+          $('#filters-btn').attr('data-filters',$(this).attr('data-filter'))
+          $('#rule-name').val($(this).data('name'))
+          $('#time').val($(this).data('interval')/3600)
+          $('#timeunit').val("hour")
+          $(this).blur()
+      })
   </script>
 
 @endpush

--- a/src/resources/views/configuration/schedule/view.blade.php
+++ b/src/resources/views/configuration/schedule/view.blade.php
@@ -1,141 +1,223 @@
-@extends('web::layouts.grids.3-9')
+@extends('web::layouts.app')
 
 @section('title', trans('web::seat.schedule'))
 @section('page_header', trans('web::seat.schedule'))
 
-@section('left')
+@section('content')
 
-  <div class="card">
-    <div class="card-header">
-      <h3 class="card-title">{{ trans('web::seat.new_schedule') }}</h3>
-    </div>
-    <div class="card-body">
+  <div class="row">
+    <div class="col-md-3">
 
-      <form role="form" action="{{ route('seatcore::configuration.schedule.new') }}" method="post">
-        {{ csrf_field() }}
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ trans('web::seat.new_schedule') }}</h3>
+        </div>
+        <div class="card-body">
 
-        <div class="box-body">
+          <form role="form" action="{{ route('seatcore::configuration.schedule.new') }}" method="post">
+            {{ csrf_field() }}
 
-          <div class="form-group">
-            <label for="command">{{ trans('web::seat.available_commands') }}</label>
-            <select name="command" id="available_commands" class="form-control" style="width: 100%;">
+            <div class="box-body">
 
-              @foreach($commands as $name => $data)
+              <div class="form-group">
+                <label for="command">{{ trans('web::seat.available_commands') }}</label>
+                <select name="command" id="available_commands" class="form-control" style="width: 100%;">
 
-                <option value="{{ $name }}"
-                        @if($name == old('command'))
-                        selected
-                        @endif
-                >
-                  {{ $name }}
-                </option>
+                  @foreach($commands as $name => $data)
 
-              @endforeach
+                    <option value="{{ $name }}"
+                            @if($name == old('command'))
+                              selected
+                            @endif
+                    >
+                      {{ $name }}
+                    </option>
 
-            </select>
-          </div>
+                  @endforeach
 
-          <div class="form-group">
-            <label for="expression">{{ trans('web::seat.cron_expression') }}</label>
-            <select name="expression" id="available_expressions" class="form-control" style="width: 100%;">
+                </select>
+              </div>
 
-              @foreach($expressions as $name => $expression)
+              <div class="form-group">
+                <label for="expression">{{ trans('web::seat.cron_expression') }}</label>
+                <select name="expression" id="available_expressions" class="form-control" style="width: 100%;">
 
-                <option value="{{ $expression }}"
-                        @if($expression == old('expression'))
-                        selected
-                        @endif
-                >
-                  {{ $name }}
-                </option>
+                  @foreach($expressions as $name => $expression)
 
-              @endforeach
+                    <option value="{{ $expression }}"
+                            @if($expression == old('expression'))
+                              selected
+                            @endif
+                    >
+                      {{ $name }}
+                    </option>
 
-            </select>
-            <p class="form-text text-muted mb-0">
-              <span id="expression"></span><br>
-              {{ trans('web::seat.choose_prepop') }}
-            </p>
-          </div>
+                  @endforeach
+
+                </select>
+                <p class="form-text text-muted mb-0">
+                  <span id="expression"></span><br>
+                  {{ trans('web::seat.choose_prepop') }}
+                </p>
+              </div>
+
+            </div>
+            <!-- /.box-body -->
+
+            <div class="box-footer">
+              <button type="submit" class="btn btn-success float-right">
+                <i class="fas fa-plus-square"></i>
+                {{ trans('web::seat.add_scheduled') }}
+              </button>
+            </div>
+          </form>
 
         </div>
-        <!-- /.box-body -->
+      </div>
+    </div>
 
-        <div class="box-footer">
-          <button type="submit" class="btn btn-success float-right">
-            <i class="fas fa-plus-square"></i>
-            {{ trans('web::seat.add_scheduled') }}
-          </button>
+    {{-- Job Schedule Table --}}
+
+    <div class="col-md-9">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ trans('web::seat.current_schedule') }}</h3>
         </div>
-      </form>
+        <div class="card-body">
 
-    </div>
-  </div>
-
-@stop
-
-@section('right')
-
-  <div class="card">
-    <div class="card-header">
-      <h3 class="card-title">{{ trans('web::seat.current_schedule') }}</h3>
-    </div>
-    <div class="card-body">
-
-      <table class="table table-sm table-condensed table-hover table-striped">
-        <thead>
-          <tr>
-            <th>{{ trans('web::seat.command') }}</th>
-            <th>{{ trans('web::seat.cron') }}</th>
-            <th>{{ trans('web::seat.allow_overlap') }}</th>
-            <th>{{ trans('web::seat.allow_maintenance') }}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-
-          @foreach($schedule as $job)
-
+          <table class="table table-sm table-condensed table-hover table-striped">
+            <thead>
             <tr>
-              <td>{{ $job->command }}</td>
-              <td>{{ $job->expression }}</td>
-              <td>{{ $job->allow_overlap }}</td>
-              <td>{{ $job->allow_maintenance }}</td>
-              <td>
-                <a href="{{ route('seatcore::configuration.schedule.delete', ['schedule_id' => $job->id]) }}" type="button"
-                   class="btn btn-danger btn-sm confirmlink">
-                  <i class="fas fa-trash-alt"></i>
-                  {{ trans('web::seat.delete') }}
-                </a>
-              </td>
+              <th>{{ trans('web::seat.command') }}</th>
+              <th>{{ trans('web::seat.cron') }}</th>
+              <th>{{ trans('web::seat.allow_overlap') }}</th>
+              <th>{{ trans('web::seat.allow_maintenance') }}</th>
+              <th></th>
             </tr>
+            </thead>
+            <tbody>
 
-          @endforeach
+            @foreach($schedule as $job)
 
-        </tbody>
-      </table>
+              <tr>
+                <td>{{ $job->command }}</td>
+                <td>{{ $job->expression }}</td>
+                <td>{{ $job->allow_overlap }}</td>
+                <td>{{ $job->allow_maintenance }}</td>
+                <td>
+                  <a href="{{ route('seatcore::configuration.schedule.delete', ['schedule_id' => $job->id]) }}"
+                     type="button"
+                     class="btn btn-danger btn-sm confirmlink">
+                    <i class="fas fa-trash-alt"></i>
+                    {{ trans('web::seat.delete') }}
+                  </a>
+                </td>
+              </tr>
 
-    </div>
-    <div class="card-footer">
-      <i class="text-muted float-right">{{ count($schedule) }} {{ trans('web::seat.scheduled_commands') }}</i>
+            @endforeach
+
+            </tbody>
+          </table>
+
+        </div>
+        <div class="card-footer">
+          <i class="text-muted float-right">{{ count($schedule) }} {{ trans('web::seat.scheduled_commands') }}</i>
+        </div>
+      </div>
     </div>
   </div>
+
+
+  {{-- Character scheduling UI --}}
+  <div class="row">
+
+    <div class="col-md-3">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ trans('web::seat.new_character_scheduling_rule') }}</h3>
+        </div>
+        <div class="card-body">
+          <form action="{{ route('seatcore::configuration.schedule.rule.create') }}" method="POST">
+            @csrf
+
+            <div class="form-group">
+              <label for="rule-name">{{ trans_choice('web::seat.name', 1) }}</label>
+              <input type="text" id="rule-name" name="name"
+                     placeholder="{{ trans('web::seat.name_input_placeholder') }}" class="form-control">
+            </div>
+
+            <div class="form-group">
+              <label for="time">{{ trans('web::seat.update_interval') }}</label>
+              <div class="row mx-0">
+                <input class="form-control col-md-9" type="number" name="time" value="1" min="1" step="0.01" id="time">
+                <select name="timeunit" class="form-control col-md-3">
+                  <option selected value="hour">{{trans('web::seat.hour')}}</option>
+                  <option value="day">{{trans('web::seat.day')}}</option>
+                  <option value="week">{{trans('web::seat.week')}}</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="form-group">
+              @include('web::components.filters.buttons.filters', ['rules' => [], 'buttonText'=>'Configure Character Filter'])
+            </div>
+
+            <input type="hidden" name="filters" value="{}" />
+
+            <button type="submit" class="btn btn-success float-right">
+              <i class="fas fa-plus-square"></i>
+              {{trans('web::seat.add')}}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-9">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{{ trans('web::seat.character_scheduling_rules') }}</h3>
+        </div>
+        <div class="card-body">
+          <table class="table table-sm table-condensed table-hover table-striped">
+            <thead>
+            <tr>
+              <th>{{trans_choice('web::seat.rule', 1)}}</th>
+              <th>{{trans('web::seat.update_interval')}}</th>
+              <th>{{trans('web::seat.action')}}</th>
+            </tr>
+            </thead>
+            <tbody>
+
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+
+
+  @include('web::components.filters.modals.filters.filters', [
+    'filters' => $characterFilterRules,
+  ])
 
 @stop
 
 @push('javascript')
 
-<script>
-  $("#available_commands, #available_expressions").select2({
-    tags: true
-  });
-</script>
+  <script>
+      $("#available_commands, #available_expressions").select2({
+          tags: true
+      });
+  </script>
 
-<script>
-  $("#available_expressions").on("change", function () {
-    $("span#expression").html(
-        "Cron: <b>" + this.value.replace("<", "") + "</b>");
-  });
-</script>
+  <script>
+      $("#available_expressions").on("change", function () {
+          $("span#expression").html(
+              "Cron: <b>" + this.value.replace("<", "") + "</b>");
+      });
+  </script>
 
 @endpush

--- a/src/resources/views/squads/create.blade.php
+++ b/src/resources/views/squads/create.blade.php
@@ -66,17 +66,7 @@
   </div>
 
   @include('web::components.filters.modals.filters.filters', [
-    'filters' => [
-      (object) ['name' => 'scopes', 'src' => route('seatcore::fastlookup.scopes'), 'path' => 'refresh_token', 'field' => 'scopes', 'label' => 'Scopes'],
-        (object) ['name' => 'character', 'src' => route('seatcore::fastlookup.characters'), 'path' => '', 'field' => 'character_id', 'label' => 'Character'],
-        (object) ['name' => 'title', 'src' => route('seatcore::fastlookup.titles'), 'path' => 'titles', 'field' => 'id', 'label' => 'Title'],
-        (object) ['name' => 'corporation', 'src' => route('seatcore::fastlookup.corporations'), 'path' => 'affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
-        (object) ['name' => 'alliance', 'src' => route('seatcore::fastlookup.alliances'), 'path' => 'affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
-        (object) ['name' => 'skill', 'src' => route('seatcore::fastlookup.skills'), 'path' => 'skills', 'field' => 'skill_id', 'label' => 'Skill'],
-        (object) ['name' => 'skill_level', 'src' => [['id' => 1, 'text' => 'Level 1'], ['id' => 2, 'text' => 'Level 2'], ['id' => 3, 'text' => 'Level 3'], ['id' => 4, 'text' => 'Level 4'], ['id' => 5, 'text' => 'Level 5']], 'path' => 'skills', 'field' => 'trained_skill_level', 'label' => 'Skill Level'],
-        (object) ['name' => 'type', 'src' => route('seatcore::fastlookup.items'), 'path' => 'assets', 'field' => 'type_id', 'label' => 'Item'],
-        (object) ['name' => 'role', 'src' => route('seatcore::fastlookup.roles'), 'path' => 'corporation_roles', 'field' => 'role', 'label' => 'Role'],
-    ],
+    'filters' => $characterFilterRules,
   ])
 @endsection
 

--- a/src/resources/views/squads/edit.blade.php
+++ b/src/resources/views/squads/edit.blade.php
@@ -83,17 +83,7 @@
   </div>
 
   @include('web::components.filters.modals.filters.filters', [
-    'filters' => [
-        (object) ['name' => 'scopes', 'src' => route('seatcore::fastlookup.scopes'), 'path' => 'refresh_token', 'field' => 'scopes', 'label' => 'Scopes'],
-        (object) ['name' => 'character', 'src' => route('seatcore::fastlookup.characters'), 'path' => '', 'field' => 'character_id', 'label' => 'Character'],
-        (object) ['name' => 'title', 'src' => route('seatcore::fastlookup.titles'), 'path' => 'titles', 'field' => 'id', 'label' => 'Title'],
-        (object) ['name' => 'corporation', 'src' => route('seatcore::fastlookup.corporations'), 'path' => 'affiliation', 'field' => 'corporation_id', 'label' => 'Corporation'],
-        (object) ['name' => 'alliance', 'src' => route('seatcore::fastlookup.alliances'), 'path' => 'affiliation', 'field' => 'alliance_id', 'label' => 'Alliance'],
-        (object) ['name' => 'skill', 'src' => route('seatcore::fastlookup.skills'), 'path' => 'skills', 'field' => 'skill_id', 'label' => 'Skill'],
-        (object) ['name' => 'skill_level', 'src' => [['id' => 1, 'text' => 'Level 1'], ['id' => 2, 'text' => 'Level 2'], ['id' => 3, 'text' => 'Level 3'], ['id' => 4, 'text' => 'Level 4'], ['id' => 5, 'text' => 'Level 5']], 'path' => 'skills', 'field' => 'trained_skill_level', 'label' => 'Skill Level'],
-        (object) ['name' => 'type', 'src' => route('seatcore::fastlookup.items'), 'path' => 'assets', 'field' => 'type_id', 'label' => 'Item'],
-        (object) ['name' => 'role', 'src' => route('seatcore::fastlookup.roles'), 'path' => 'corporation_roles', 'field' => 'role', 'label' => 'Role'],
-    ],
+    'filters' => $characterFilterRules,
   ])
 @endsection
 

--- a/tests/Acl/AlliancePolicyTest.php
+++ b/tests/Acl/AlliancePolicyTest.php
@@ -149,6 +149,9 @@ class AlliancePolicyTest extends TestCase
      */
     public function testAlliancePermissionsAsDelegatedCharacter()
     {
+        // make sure this doesn't generate observer events that trigger the squads logic
+        CharacterAffiliation::unsetEventDispatcher();
+
         $permissions = array_keys(require __DIR__ . '/../../src/Config/Permissions/alliance.php');
 
         $user = User::factory()->create();
@@ -199,6 +202,9 @@ class AlliancePolicyTest extends TestCase
      */
     public function testAlliancePermissionsAsDelegatedCorporation()
     {
+        // make sure this doesn't generate observer events that trigger the squads logic
+        CharacterAffiliation::unsetEventDispatcher();
+
         $permissions = array_keys(require __DIR__ . '/../../src/Config/Permissions/alliance.php');
 
         $user = User::factory()->create();

--- a/tests/Acl/CharacterPolicyTest.php
+++ b/tests/Acl/CharacterPolicyTest.php
@@ -258,6 +258,9 @@ class CharacterPolicyTest extends TestCase
      */
     public function testCharacterPermissionsAsDelegatedCorporation()
     {
+        // make sure this doesn't generate observer events that trigger the squads logic
+        CharacterAffiliation::unsetEventDispatcher();
+
         $permissions = array_keys(require __DIR__ . '/../../src/Config/Permissions/character.php');
 
         $user = User::factory()->create();
@@ -313,6 +316,9 @@ class CharacterPolicyTest extends TestCase
      */
     public function testCharacterPermissionsAsDelegatedAlliance()
     {
+        // make sure this doesn't generate observer events that trigger the squads logic
+        CharacterAffiliation::unsetEventDispatcher();
+
         $permissions = array_keys(require __DIR__ . '/../../src/Config/Permissions/character.php');
 
         $user = User::factory()->create();

--- a/tests/Acl/CorporationPolicyTest.php
+++ b/tests/Acl/CorporationPolicyTest.php
@@ -186,6 +186,9 @@ class CorporationPolicyTest extends TestCase
      */
     public function testCorporationPermissionsAsDelegatedCharacter()
     {
+        // make sure this doesn't generate observer events that trigger the squads logic
+        CharacterAffiliation::unsetEventDispatcher();
+
         $permissions = array_keys(require __DIR__ . '/../../src/Config/Permissions/corporation.php');
 
         $user = User::factory()->create();


### PR DESCRIPTION
This PR is the web side of bringing per-character esi update intervals to seat. It builds upon https://github.com/eveseat/eveapi/pull/409 and adds a user interface+automation using squad filter for it.

![Bildschirmfoto 2024-08-21 um 11 14 48](https://github.com/user-attachments/assets/3f8e2389-dbff-4127-aca3-8032a5428b4f)

How it works: Admins can specify "character scheduling rules". They are a squad-style character filter and an associated update interval. For every character, seat checks if they are eligible for a scheduling rule by checking the filter of that rule. From all rules that apply to a character, the rule with the shortest update interval is used. If no rule applies, the old default of 1 hour applies.

Internal changes: This PR refactors the observer side of squads so that the observers can also be used for other kinds of filters, like the character scheduling rules. The available filter rules are moved to a config file.

This PR introduces quite a lot of changes. If it is too difficult to review, it is possible to go through commit by commit and it generally should make more sense.