### PR TITLE
fix: allow updating character scheduling rules for new tokens

### DIFF
--- a/src/Http/Controllers/Configuration/ScheduleController.php
+++ b/src/Http/Controllers/Configuration/ScheduleController.php
@@ -118,8 +118,11 @@ class ScheduleController extends Controller
         $rule->filter = $request->filters;
         $rule->save();
 
-        RefreshToken::all()->each(function ($token) {
-            CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+        // chunk this to avoid out-of-memory issues on large installs
+        RefreshToken::chunk(200, function ($tokens) {
+            foreach ($tokens as $token) {
+                CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+            }
         });
 
         return redirect()->back()
@@ -134,8 +137,11 @@ class ScheduleController extends Controller
 
         CharacterSchedulingRule::destroy($request->rule_id);
 
-        RefreshToken::all()->each(function ($token) {
-           CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+        // chunk this to avoid out-of-memory issues on large installs
+        RefreshToken::chunk(200, function ($tokens) {
+            foreach ($tokens as $token) {
+                CharacterSchedulingRule::updateRefreshTokenSchedule($token);
+            }
         });
 
         return redirect()->back()->with('success', 'Successfully removed character scheduling rule!');

--- a/src/Models/CharacterSchedulingRule.php
+++ b/src/Models/CharacterSchedulingRule.php
@@ -66,6 +66,7 @@ class CharacterSchedulingRule extends ExtensibleModel
         if($schedule === null) {
             $schedule = new RefreshTokenSchedule();
             $schedule->character_id = $token->character_id;
+            $schedule->last_update = now()->subYears(10); // Hopefully this is far enough in the past to mean never?
         }
 
         $schedule->update_interval = self::getCharacterSchedulingInterval($token->character);


### PR DESCRIPTION
Some reported me that they get a error 500 when updating rules just after upgrading. This is the same bug that crypta discovered. It turns out I missed a line while copy&pasting the original fix.

Error:
```
[previous exception] [object] (PDOException(code: HY000): SQLSTATE[HY000]: General error: 1364 Field 'last_update' doesn't have a default value at /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45)
[stacktrace]
#0 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php(45): PDOStatement->execute()
#1 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(816): Illuminate\\Database\\MySqlConnection->Illuminate\\Database\\{closure}('insert into `re...', Array)
#2 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(783): Illuminate\\Database\\Connection->runQueryCallback('insert into `re...', Array, Object(Closure))
#3 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php(34): Illuminate\\Database\\Connection->run('insert into `re...', Array, Object(Closure))
#4 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3456): Illuminate\\Database\\MySqlConnection->insert('insert into `re...', Array)
#5 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1982): Illuminate\\Database\\Query\\Builder->insert(Array)
#6 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1310): Illuminate\\Database\\Eloquent\\Builder->__call('insert', Array)
#7 /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1138): Illuminate\\Database\\Eloquent\\Model->performInsert(Object(Illuminate\\Database\\Eloquent\\Builder))
#8 /var/www/seat/vendor/eveseat/web/src/Models/CharacterSchedulingRule.php(72): Illuminate\\Database\\Eloquent\\Model->save()
#9 /var/www/seat/vendor/eveseat/web/src/Http/Controllers/Configuration/ScheduleController.php(138): Seat\\Web\\Models\\CharacterSchedulingRule::updateRefreshTokenSchedule(Object(Seat\\Eveapi\\Models\\RefreshToken))
#10 /var/www/seat/vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php(240): Seat\\Web\\Http\\Controllers\\Configuration\\ScheduleController->Seat\\Web\\Http\\Controllers\\Configuration\\{closure}(Object(Seat\\Eveapi\\Models\\RefreshToken), 0)
#11 /var/www/seat/vendor/eveseat/web/src/Http/Controllers/Configuration/ScheduleController.php(137): Illuminate\\Support\\Collection->each(Object(Closure))
#12 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): Seat\\Web\\Http\\Controllers\\Configuration\\ScheduleController->deleteSchedulingRule(Object(Illuminate\\Http\\Request))
#13 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(43): Illuminate\\Routing\\Controller->callAction('deleteSchedulin...', Array)
#14 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Route.php(259): Illuminate\\Routing\\ControllerDispatcher->dispatch(Object(Illuminate\\Routing\\Route), Object(Seat\\Web\\Http\\Controllers\\Configuration\\ScheduleController), 'deleteSchedulin...')
#15 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Route.php(205): Illuminate\\Routing\\Route->runController()
#16 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Router.php(806): Illuminate\\Routing\\Route->run()
#17 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): Illuminate\\Routing\\Router->Illuminate\\Routing\\{closure}(Object(Illuminate\\Http\\Request))
#18 /var/www/seat/vendor/laravel/framework/src/Illuminate/Auth/Middleware/Authorize.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#19 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Auth\\Middleware\\Authorize->handle(Object(Illuminate\\Http\\Request), Object(Closure), 'global.superuse...')
#20 /var/www/seat/vendor/eveseat/web/src/Http/Middleware/Locale.php(44): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#21 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Seat\\Web\\Http\\Middleware\\Locale->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#22 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php(50): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#23 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Routing\\Middleware\\SubstituteBindings->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#24 /var/www/seat/vendor/laravel/framework/src/Illuminate/Auth/Middleware/Authenticate.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#25 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Auth\\Middleware\\Authenticate->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#26 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php(78): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#27 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#28 /var/www/seat/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php(49): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#29 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\View\\Middleware\\ShareErrorsFromSession->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#30 /var/www/seat/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(121): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#31 /var/www/seat/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(64): Illuminate\\Session\\Middleware\\StartSession->handleStatefulRequest(Object(Illuminate\\Http\\Request), Object(Illuminate\\Session\\Store), Object(Closure))
#32 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Session\\Middleware\\StartSession->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#33 /var/www/seat/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php(37): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#34 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#35 /var/www/seat/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(67): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#36 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Cookie\\Middleware\\EncryptCookies->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#37 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#38 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Router.php(805): Illuminate\\Pipeline\\Pipeline->then(Object(Closure))
#39 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Router.php(784): Illuminate\\Routing\\Router->runRouteWithinStack(Object(Illuminate\\Routing\\Route), Object(Illuminate\\Http\\Request))
#40 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Router.php(748): Illuminate\\Routing\\Router->runRoute(Object(Illuminate\\Http\\Request), Object(Illuminate\\Routing\\Route))
#41 /var/www/seat/vendor/laravel/framework/src/Illuminate/Routing/Router.php(737): Illuminate\\Routing\\Router->dispatchToRoute(Object(Illuminate\\Http\\Request))
#42 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(200): Illuminate\\Routing\\Router->dispatch(Object(Illuminate\\Http\\Request))
#43 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): Illuminate\\Foundation\\Http\\Kernel->Illuminate\\Foundation\\Http\\{closure}(Object(Illuminate\\Http\\Request))
#44 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#45 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php(31): Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#46 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Foundation\\Http\\Middleware\\ConvertEmptyStringsToNull->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#47 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#48 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php(40): Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#49 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Foundation\\Http\\Middleware\\TrimStrings->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#50 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php(27): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#51 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#52 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php(99): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#53 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Foundation\\Http\\Middleware\\PreventRequestsDuringMaintenance->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#54 /var/www/seat/vendor/laravel/framework/src/Illuminate/Http/Middleware/TrustProxies.php(39): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#55 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\\Http\\Middleware\\TrustProxies->handle(Object(Illuminate\\Http\\Request), Object(Closure))
#56 /var/www/seat/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}(Object(Illuminate\\Http\\Request))
#57 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(175): Illuminate\\Pipeline\\Pipeline->then(Object(Closure))
#58 /var/www/seat/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(144): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter(Object(Illuminate\\Http\\Request))
#59 /var/www/seat/public/index.php(51): Illuminate\\Foundation\\Http\\Kernel->handle(Object(Illuminate\\Http\\Request))
#60 {main}
```

Also, I've decided to batch the refresh token updates so we don't risk running out of memory when chaning rules.