### PR TITLE
Prevent squad update from running out of memory with many squads

### DIFF
--- a/src/Jobs/UpdateCharacterFilters.php
+++ b/src/Jobs/UpdateCharacterFilters.php
@@ -45,8 +45,8 @@ class UpdateCharacterFilters implements ShouldQueue
      */
     public function handle()
     {
-        // without chunking, we can run out of memory on large installs
-        CharacterInfo::chunk(200, function ($characters) {
+        // Without chunking, we can run out of memory on large installs.
+        CharacterInfo::with('user.squads')->chunk(5, function ($characters) {
             foreach ($characters as $character){
                 event(new CharacterFilterDataUpdate($character));
             }


### PR DESCRIPTION
Installs with many squads (50+) run out of ram when attempting to run `seat:filters:update`. By having fewer characters in RAM at a time, this should no longer happen. 

Going from 200 to 5 characters at a time might seem a bit drastic, but experimentally a user had to increase the memory limit about 10x to make it pass. Additionally, we want some margin of safety.