### PR TITLE
fix: trigger normal form events when using .confirm[delete][form]

### DIFF
--- a/src/resources/js/seat.js
+++ b/src/resources/js/seat.js
@@ -24,7 +24,7 @@ $(document).on("click", ".confirmform", function (e) {
     }
     bootbox.confirm(message, function (confirmed) {
         if (confirmed) {
-            currentForm.submit();
+            currentForm.get(0).requestSubmit(); // requestSubmit is not supported by jquery, so access the rwa DOM element
         }
     });
 });
@@ -47,7 +47,7 @@ $(document).on("click", ".confirmdelete", function (e) {
     }
     bootbox.confirm(message, function (confirmed) {
         if (confirmed) {
-            currentForm.submit();
+            currentForm.get(0).requestSubmit(); // requestSubmit is not supported by jquery, so access the rwa DOM element
         }
     });
 });


### PR DESCRIPTION
Using .submit() to submit a form from javascript doesn't trigger the form's `submit` event. `submit` is commonly used for form validation or injecting data from javascript. Instead of `submit`, we can use `requestSubmit`

See also: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit#usage_notes