### PR TITLE
fix: add styling back to logo

### DIFF
--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 
   <div class="text-center mb-4">
-    <img src="{{ asset('web/img/seat.svg') }}" alt="SeAT Logo" />
+    <img class="login-logo" src="{{ asset('web/img/seat.svg') }}" alt="SeAT Logo" />
     <br>
     <a href="{{ config('app.url') }}" class="navbar-brand navbar-brand-autodark">
       <span class="display-4 seat-font">S<b>e</b>AT</span>


### PR DESCRIPTION
Adding the login-logo back to the seat logo on the login page to allow for css modification.