### PR TITLE
fix: sso scope profile migration without any profile

### DIFF
--- a/src/database/migrations/2025_02_11_000000_remove_deprecated_sso_scopes_profiles.php
+++ b/src/database/migrations/2025_02_11_000000_remove_deprecated_sso_scopes_profiles.php
@@ -40,8 +40,13 @@ class RemoveDeprecatedSsoScopesProfiles extends Migration
             'esi-characters.read_opportunities.v1',
         ];
 
+        $sso_scopes_setting = DB::table('global_settings')->where('name', 'sso_scopes')->first();
+
+        // if no sso scope settings have been configured, we don't have anything to migrate
+        if($sso_scopes_setting === null) return;
+
         // Fix the global_settings
-        $profiles = json_decode(DB::table('global_settings')->where('name', 'sso_scopes')->first()->value);
+        $profiles = json_decode($sso_scopes_setting->value);
         foreach($profiles as &$profile) {
             foreach($remove_scopes as $rs) {
                 foreach(array_keys($profile->scopes, $rs, true) as $key) {


### PR DESCRIPTION
Fixes the following migration issue reported by `@nunu` on discord:
```
front-1      |    INFO  Running migrations.
front-1      | 
front-1      |   2025_02_11_000000_remove_deprecated_sso_scopes_profiles ........... 1ms FAIL
front-1      | 
front-1      | In 2025_02_11_000000_remove_deprecated_sso_scopes_profiles.php line 44:
front-1      |
front-1      |   Attempt to read property "value" on null
front-1      |
front-1      | 
```

This happens if not sso scope profile has been set up.