### PR TITLE
use bootstrap classes instead of style attribute for button

### DIFF
--- a/src/resources/views/profile/view.blade.php
+++ b/src/resources/views/profile/view.blade.php
@@ -227,7 +227,7 @@
     <p>{{ trans('web::seat.third_party_access') }}</p>
     <hr/>
     <p class="mb-0 text-right">
-      <a class="btn btn-sm btn-warning" style="color: inherit; text-decoration: inherit;" href="https://community.eveonline.com/support/third-party-applications/" target="_blank">{{ trans('web::seat.view_third_party_access') }}</a>
+      <a class="btn btn-sm btn-warning text-decoration-none" href="https://community.eveonline.com/support/third-party-applications/" target="_blank">{{ trans('web::seat.view_third_party_access') }}</a>
     </p>
   </div>
 


### PR DESCRIPTION
I've been playing around with some custom seat skins. This one button directly next to the skin selector has been really ugly because it overrides some button styles. With the default and jet skin, it looks basically unchanged, but with any other skins, this button now automatically looks good.

### Before
![Bildschirmfoto 2025-04-18 um 11 06 03](https://github.com/user-attachments/assets/748f367d-ae23-460b-b15f-d512b315e2dc)
![Bildschirmfoto 2025-04-18 um 11 05 53](https://github.com/user-attachments/assets/17466406-af50-4a0c-b050-22cefc33ed81)
### After
![Bildschirmfoto 2025-04-18 um 11 06 14](https://github.com/user-attachments/assets/f348a521-43d1-4806-898b-3aa232100d7d)
![Bildschirmfoto 2025-04-18 um 11 05 39](https://github.com/user-attachments/assets/c8a1931f-068e-4a35-8d43-61bf9c756d0c)
