### PR TITLE
feature: display scope profile in scopes view

### DIFF
--- a/src/Http/Controllers/Profile/ProfileController.php
+++ b/src/Http/Controllers/Profile/ProfileController.php
@@ -84,7 +84,9 @@ class ProfileController extends Controller
             ->where('user_id', $user_id)
             ->first();
 
-        return view('web::profile.modals.scopes.content', ['scopes' => $token->scopes]);
+        $profile_name = collect(setting('sso_scopes'))->where('id', $token->scopes_profile)->first()->name ?? null;
+
+        return view('web::profile.modals.scopes.content', ['scopes' => $token->scopes, "profile_name"=>$profile_name]);
     }
 
     /**

--- a/src/Http/Controllers/Profile/ProfileController.php
+++ b/src/Http/Controllers/Profile/ProfileController.php
@@ -86,7 +86,7 @@ class ProfileController extends Controller
 
         $profile_name = collect(setting('sso_scopes'))->where('id', $token->scopes_profile)->first()->name ?? null;
 
-        return view('web::profile.modals.scopes.content', ['scopes' => $token->scopes, "profile_name"=>$profile_name]);
+        return view('web::profile.modals.scopes.content', ['scopes' => $token->scopes, 'profile_name' => $profile_name]);
     }
 
     /**

--- a/src/resources/lang/de/seat.php
+++ b/src/resources/lang/de/seat.php
@@ -704,6 +704,8 @@ return [
     'user_sharelink' => 'User Sharing',
     'user_sharelink_description' => 'You can generate a sharing link that can be shared with other SeAT users to allow them to view your linked characters information.',
     'user_sharelink_generate' => 'Generate Link',
+    'unknown_scopes_profile' => 'Unbekannt (SSO-Scope-Profil nicht gefunden)',
+    'scopes_profile' => 'SSO-Scope-Profil',
 
     // Queue
     'queue_manage' => 'Warteschlange Verwaltung',

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -717,6 +717,8 @@ return [
     'user_sharelink' => 'User Sharing',
     'user_sharelink_description' => 'You can generate a sharing link that can be shared with other SeAT users to allow them to view your linked characters information.',
     'user_sharelink_generate' => 'Generate Link',
+    'unknown_scopes_profile' => 'Unknown (Profile not found)',
+    'scopes_profile' => 'Scopes Profile',
 
     // Queue
     'queue_manage' => 'Queue Management',

--- a/src/resources/views/profile/modals/scopes/content.blade.php
+++ b/src/resources/views/profile/modals/scopes/content.blade.php
@@ -7,3 +7,15 @@
     @endforeach
   </tbody>
 </table>
+<p>
+    <b>{{ trans("web::seat.scopes_profile") }}</b>:
+    @if($profile_name !== null)
+        <span class="text-success">
+            {{ $profile_name }}
+        </span>
+    @else
+        <span class="text-danger">
+            {{ trans("web::seat.unknown_scopes_profile") }}
+        </span>
+    @endif
+</p>


### PR DESCRIPTION
With this PR, in addition to the scopes granted on a token, we also show the linked scope profile. This is relevant to e.g. debug issues when a scope profile gets deleted, but there are still tokens linked to it or when assessing the effect of changing a token profile.

![Bildschirmfoto 2025-05-29 um 11 14 44](https://github.com/user-attachments/assets/afc266a2-0863-4f0a-abb6-788a4da407a4)
