### PR TITLE
Moon Reporter Feature: Moon Notes

### DIFF
--- a/src/Http/Controllers/Tools/MoonsController.php
+++ b/src/Http/Controllers/Tools/MoonsController.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Web\Http\Controllers\Tools;
 
+use Illuminate\Http\Request;
 use Seat\Eveapi\Models\Sde\Moon;
 use Seat\Services\ReportParser\Exceptions\InvalidReportException;
 use Seat\Services\ReportParser\Parsers\MoonReport;
@@ -158,5 +159,20 @@ class MoonsController extends Controller
         $report->delete();
 
         return redirect()->back();
+    }
+
+    /**
+     * @param int $moon
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function edit(int $moon)
+    {
+        $moon = UniverseMoonReport::with('content')->where('moon_id',$moon)->first();
+        if($moon == null) return response()->json([],400);
+
+        return response()->json([
+            'report' => $moon->formatReport(),
+            'notes' => $moon->notes,
+        ]);
     }
 }

--- a/src/Http/Controllers/Tools/MoonsController.php
+++ b/src/Http/Controllers/Tools/MoonsController.php
@@ -125,6 +125,7 @@ class MoonsController extends Controller
                         $universe_moon = UniverseMoonReport::firstOrNew(['moon_id' => $component->moonID]);
                         $universe_moon->user_id = auth()->user()->getAuthIdentifier();
                         $universe_moon->updated_at = now();
+                        $universe_moon->notes = $request->notes;
                         $universe_moon->save();
 
                         // search for any existing and outdated report regarding current moon

--- a/src/Http/Routes/Tools/Moons.php
+++ b/src/Http/Routes/Tools/Moons.php
@@ -34,6 +34,10 @@ Route::group([
         ->name('seatcore::tools.moons.show')
         ->uses('MoonsController@show');
 
+    Route::get('/{id}/edit')
+        ->name('seatcore::tools.moons.edit')
+        ->uses('MoonsController@edit');
+
     Route::post('/')
         ->name('seatcore::tools.moons.store')
         ->uses('MoonsController@store')

--- a/src/Models/UniverseMoonReport.php
+++ b/src/Models/UniverseMoonReport.php
@@ -148,6 +148,29 @@ class UniverseMoonReport extends Model
     }
 
     /**
+     * Converts the moon back into a report string
+     *
+     * @return string
+     */
+    public function formatReport(): string
+    {
+        // header + moon name
+        $report = sprintf("Moon	Moon Product\tQuantity\tOre TypeID\tSolarSystemID\tPlanetID\tMoonID\n%s\n",$this->moon->name);
+
+        foreach ($this->content as $content){
+            $report .= sprintf("\t%s\t%F\t%d\t%d\t%d\t%d\n",
+                $content->typeName,
+                $content->pivot->rate,
+                $content->typeID,
+                $this->moon->system_id,
+                $this->moon->planet_id,
+                $this->moon_id);
+        }
+
+        return $report;
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function content()

--- a/src/database/migrations/2025_07_21_000000_add_moon_report_notes.php
+++ b/src/database/migrations/2025_07_21_000000_add_moon_report_notes.php
@@ -20,33 +20,33 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Web\Http\Validation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-use Illuminate\Foundation\Http\FormRequest;
-
-class ProbeReport extends FormRequest
-{
+return new class extends Migration {
     /**
-     * Authorize the request by default.
+     * Run the migrations.
      *
-     * @return bool
+     * @return void
      */
-    public function authorize()
+    public function up()
     {
-
-        return true;
+        Schema::table('universe_moon_reports', function (Blueprint $table){
+            $table->string('notes')->default('');
+        });
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * Reverse the migrations.
      *
-     * @return array
+     * @return void
      */
-    public function rules()
+    public function down()
     {
-        return [
-            'moon-report' => 'required',
-            'notes' => 'present|string'
-        ];
+        Schema::table('universe_moon_reports', function (Blueprint $table){
+            $table->dropColumn('notes');
+        });
     }
-}
+};

--- a/src/resources/lang/en/moons.php
+++ b/src/resources/lang/en/moons.php
@@ -55,4 +55,7 @@ return [
     'filter_by_constellation' => 'Filter by constellation',
     'filter_by_system' => 'Filter by system',
     'import' => 'Import',
+    'notes' => 'Notes',
+    'notes_instruction' => 'You can enter some notes about the moon(s) here. When adding multiple moons, the note will be added to all of them.',
+    'notes_placeholder' => 'Enter your notes here',
 ];

--- a/src/resources/views/tools/moons/buttons/action.blade.php
+++ b/src/resources/views/tools/moons/buttons/action.blade.php
@@ -1,4 +1,5 @@
 <div class="btn-group btn-group-sm">
     @include('web::tools.moons.buttons.show')
+    @include('web::tools.moons.buttons.edit')
     @include('web::tools.moons.buttons.delete')
 </div>

--- a/src/resources/views/tools/moons/buttons/edit.blade.php
+++ b/src/resources/views/tools/moons/buttons/edit.blade.php
@@ -1,0 +1,3 @@
+<button type="button" class="btn btn-sm btn-secondary" data-toggle="modal" data-target="#moon-import" data-url="{{ route('seatcore::tools.moons.edit', $row->moon_id) }}">
+  <i class="fas fa-pen"></i> {{ trans_choice('web::seat.edit', 1) }}
+</button>

--- a/src/resources/views/tools/moons/modals/components/content.blade.php
+++ b/src/resources/views/tools/moons/modals/components/content.blade.php
@@ -1,4 +1,7 @@
-<h4>{{ $moon->moon->name }}</h4>
+<h4 class="d-flex">
+  <span class="mr-auto">{{ $moon->moon->name }}</span>
+  @include('web::tools.moons.buttons.edit',['row'=>$moon])
+</h4>
 <p class="lead">
   {{ trans('web::moons.yield_explanation',['volume'=>number_format(Seat\Eveapi\Models\Industry\CorporationIndustryMiningExtraction::BASE_DRILLING_VOLUME, 2),'yield'=>(setting('reprocessing_yield') ?: 0.80) * 100]) }}
 </p>

--- a/src/resources/views/tools/moons/modals/components/content.blade.php
+++ b/src/resources/views/tools/moons/modals/components/content.blade.php
@@ -16,6 +16,11 @@
   <dt>{{ trans_choice('web::moons.moon', 1) }}</dt>
   <dd>{{ $moon->moon->name }}</dd>
 
+  @if(strip_tags($moon->notes) !== "")
+    <dt>{{ trans('web::moons.notes') }}</dt>
+    <dd>{!! $moon->notes !!}</dd>
+  @endif
+
   <dt>{{trans_choice('web::moons.region', 1)}}</dt>
   <dd>{{ $moon->moon->region->name }}</dd>
 

--- a/src/resources/views/tools/moons/modals/import/import.blade.php
+++ b/src/resources/views/tools/moons/modals/import/import.blade.php
@@ -17,6 +17,14 @@
               {!! trans('web::moons.probe_report_instruction') !!}
             </p>
           </div>
+          <div class="form-group">
+            <label for="notes" class="control-label">{{ trans('web::moons.notes') }}</label>
+            <input type="hidden" id="notes" name="notes" value="" />
+            <div id="moon-notes" style="max-height: 7em"></div>
+            <p class="form-text text-muted mb-0">
+              {!! trans('web::moons.notes_instruction') !!}
+            </p>
+          </div>
         </form>
       </div>
       <div class="modal-footer">
@@ -26,3 +34,42 @@
     </div>
   </div>
 </div>
+
+@push('head')
+  <link href="{{ asset('web/css/quill.snow.css') }}" rel="stylesheet" />
+@endpush
+
+@push('javascript')
+  <script src="{{ asset('web/js/quill.min.js') }}"></script>
+
+  <script>
+
+    Quill.prototype.getHtml = function () {
+      var html = this.container.querySelector('.ql-editor').innerHTML;
+      html = html.replace(/<p>(<br>|<br\/>|<br\s\/>|\s+|)<\/p>\r\n/gmi, "");
+      return html;
+    };
+
+    var editor = new Quill('#moon-notes', {
+      modules: {
+        toolbar: [
+          [{'header': ['1', '2', '3', '4', '5', '6', false]}, {'color': []}],
+          ['bold', 'italic', 'underline', 'strike'],
+          [{'list': 'ordered'}, {'list': 'bullet'}],
+          [{'align': []}, {'indent': '-1'}, {'indent': '+1'}],
+          ['link'],
+          ['clean']
+        ]
+      },
+      placeholder: '{{ trans('web::moons.notes_placeholder') }}',
+      theme: 'snow'
+    });
+
+    editor.setContents(editor.clipboard.convert($('input[name="notes"]').val()), 'silent');
+
+    $('#moon-report-form').on('submit', function () {
+      const input = $('input[name="notes"]');
+      input.val(editor.getHtml());
+    });
+  </script>
+@endpush

--- a/src/resources/views/tools/moons/modals/import/import.blade.php
+++ b/src/resources/views/tools/moons/modals/import/import.blade.php
@@ -12,7 +12,7 @@
           {{ csrf_field() }}
           <div class="form-group">
             <label for="moon-report" class="control-label">{{ trans('web::moons.report') }}</label>
-            <textarea class="form-control" name="moon-report" id="moon-report"></textarea>
+            <textarea class="form-control" name="moon-report" id="moon-report" rows="5"></textarea>
             <p class="form-text text-muted mb-0">
               {!! trans('web::moons.probe_report_instruction') !!}
             </p>
@@ -43,7 +43,6 @@
   <script src="{{ asset('web/js/quill.min.js') }}"></script>
 
   <script>
-
     Quill.prototype.getHtml = function () {
       var html = this.container.querySelector('.ql-editor').innerHTML;
       html = html.replace(/<p>(<br>|<br\/>|<br\s\/>|\s+|)<\/p>\r\n/gmi, "");
@@ -65,11 +64,23 @@
       theme: 'snow'
     });
 
-    editor.setContents(editor.clipboard.convert($('input[name="notes"]').val()), 'silent');
-
     $('#moon-report-form').on('submit', function () {
       const input = $('input[name="notes"]');
       input.val(editor.getHtml());
     });
+
+
+    $('#moon-import').on('show.bs.modal', function (e) {
+      $('#components-detail').modal('hide')
+
+      $.ajax($(e.relatedTarget).data('url'))
+        .done(function (data) {
+          $('#moon-report').val(data.report)
+          editor.setContents(editor.clipboard.convert(data.notes), 'silent');
+        }).fail(function () {
+          $('#moon-report').val('')
+          editor.setContents(editor.clipboard.convert(''), 'silent');
+      })
+    })
   </script>
 @endpush


### PR DESCRIPTION
This PR adds notes to moons in the moon reporter.

They show up in the details view like this:
<img width="812" height="554" alt="Bildschirmfoto 2025-07-21 um 22 00 25" src="https://github.com/user-attachments/assets/22781541-522d-4461-9630-430175d2bc16" />

You can change notes using the new edit button:
<img width="1496" height="119" alt="Bildschirmfoto 2025-07-21 um 22 01 01" src="https://github.com/user-attachments/assets/6a5c106b-c861-4e7e-9c61-7f8351227fd4" />

Which opens the import/edit view:
<img width="817" height="574" alt="Bildschirmfoto 2025-07-21 um 22 01 57" src="https://github.com/user-attachments/assets/70093c01-9e39-4557-a16c-5ede90da25b4" />

You can now also change the moon contents/copy them out into other tools from the edit view.
