### PR TITLE
fix: don't show skill if we don't know its name

### DIFF
--- a/src/resources/views/character/skills.blade.php
+++ b/src/resources/views/character/skills.blade.php
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  @foreach($character->skills->groupBy('type.groupID')->chunk(2) as $skill_group_row)
+  @foreach($character->skills()->has('type.group')->get()->groupBy('type.groupID')->chunk(2) as $skill_group_row)
     <div class="row">
       <div class="col-md-12 mt-3">
         <div class="card-deck">


### PR DESCRIPTION
I've been getting some 500s because the new Advanced Armor Layering skill is not yet in the SDE. 

Instead of giving a 500 for characters with this skill, this PR will just ignore the skill.