### PR TITLE
feat: distinguish BPO/BPC icons in asset views

### DIFF
--- a/src/Http/DataTables/Common/Intel/AbstractAssetDataTable.php
+++ b/src/Http/DataTables/Common/Intel/AbstractAssetDataTable.php
@@ -49,7 +49,7 @@ abstract class AbstractAssetDataTable extends DataTable
                 return view('web::partials.type', [
                     'type_id' => $row->type->typeID,
                     'type_name' => $row->name ? sprintf('%s (%s)', $row->name, $row->type->typeName) : $row->type->typeName,
-                    'variation' => $row->type->group->categoryID == 9 ? 'bpc' : 'icon',
+                    'variation' => $row->type->group->categoryID == 9 ? ($row->is_blueprint_copy ? 'bpc' : 'bp') : 'icon',
                 ])->render();
             })
             ->editColumn('quantity', function ($row) {

--- a/src/resources/views/character/assets/modals/container/content.blade.php
+++ b/src/resources/views/character/assets/modals/container/content.blade.php
@@ -46,7 +46,7 @@
           @include('web::partials.type', [
             'type_id' => $item->type->typeID,
             'type_name' => $item->name ? sprintf('%s (%s)', $item->name, $item->type->typeName) : $item->type->typeName,
-            'variation' => $item->type->group->categoryID == 9 ? 'bpc' : 'icon',
+            'variation' => $item->type->group->categoryID == 9 ? ($item->is_blueprint_copy ? 'bpc' : 'bp') : 'icon',
           ])
         </td>
         <td>{{ number($item->quantity, 0) }}</td>

--- a/src/resources/views/corporation/assets/modals/container/content.blade.php
+++ b/src/resources/views/corporation/assets/modals/container/content.blade.php
@@ -81,7 +81,7 @@
           @include('web::partials.type', [
             'type_id' => $item->type->typeID,
             'type_name' => $item->name ? sprintf('%s (%s)', $item->name, $item->type->typeName) : $item->type->typeName,
-            'variation' => $item->type->group->categoryID == 9 ? 'bpc' : 'icon',
+            'variation' => $item->type->group->categoryID == 9 ? ($item->is_blueprint_copy ? 'bpc' : 'bp') : 'icon',
           ])
         </td>
         <td>{{ number($item->quantity, 0) }}</td>

--- a/src/resources/views/partials/assetscontents.blade.php
+++ b/src/resources/views/partials/assetscontents.blade.php
@@ -3,7 +3,7 @@
   <tr class="hidding">
     <td>{{ $asset_content->quantity }}</td>
     <td>
-      @include('web::partials.type', ['type_id' => $asset_content->type->typeID, 'type_name' => $asset_content->type->typeName, 'variation' => $asset_content->type->group->categoryID == 9 ? 'bpc' : 'icon'])
+      @include('web::partials.type', ['type_id' => $asset_content->type->typeID, 'type_name' => $asset_content->type->typeName, 'variation' => $asset_content->type->group->categoryID == 9 ? ($asset_content->is_blueprint_copy ? 'bpc' : 'bp') : 'icon'])
     </td>
     <td>{{ number_metric($asset_content->quantity * $asset_content->volume) }} m&sup3;</td>
     <td>{{ $asset_content->type->group->groupName  }}</td>


### PR DESCRIPTION
Use is_blueprint_copy flag to show correct blueprint icon (bp for BPO, bpc for BPC) instead of hardcoded bpc for all blueprints.