### PR TITLE
fix: remove admin flag from User $fillable to prevent privilege escalation

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -68,7 +68,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var array
      */
     protected $fillable = [
-        'name', 'main_character_id', 'active', 'admin',
+        'name', 'main_character_id', 'active',
     ];
 
     /**


### PR DESCRIPTION
## Security Fix: Privilege Escalation via Mass Assignment

### Vulnerability

The `User` model included `'admin'` in its `$fillable` array:

```php
protected $fillable = [
    'name', 'main_character_id', 'active', 'admin',
];
```

Laravel's mass assignment protection works by only allowing attributes listed in `$fillable` to be set via `fill()`, `create()`, or `update()` calls. Including `admin` in this list means that **any controller endpoint passing request data directly to these methods could allow an authenticated user to elevate their own privileges** by including `admin=1` in the request body.

### Impact

If any endpoint in the application (including third-party plugins) uses a pattern like:

```php
$user->fill($request->all());
$user->save();
// or
User::create($request->all());
```

An attacker could include `admin=true` in the POST body and become an administrator, gaining full access to all SeAT data, user management, and configuration.

This is classified as **CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes**.

### Fix

Removed `'admin'` from `$fillable`. The `admin` flag should only be set through explicit, privileged code paths using `forceFill()` or direct attribute assignment in contexts where the caller's authorization has already been verified.

### References

- [Laravel Documentation: Mass Assignment](https://laravel.com/docs/10.x/eloquent#mass-assignment)
- [OWASP: Mass Assignment Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html)
- [CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes](https://cwe.mitre.org/data/definitions/915.html)
- [CVE-2012-2054 - GitHub Rails mass assignment (historical reference)](https://gist.github.com/peternixey/1978249)